### PR TITLE
Remove OfflinePlayers loops

### DIFF
--- a/src/main/java/org/maxgamer/quickshop/Command/QS.java
+++ b/src/main/java/org/maxgamer/quickshop/Command/QS.java
@@ -564,11 +564,7 @@ public class QS implements CommandExecutor{
 						sender.sendMessage(
 								MsgUtil.getMessage("fee-charged-for-price-change", plugin.getEcon().format(fee)));
 						try {
-							for (OfflinePlayer player : Bukkit.getOfflinePlayers()) {
-								if (player.getName().equals(plugin.getConfig().getString("tax-account"))) {
-									plugin.getEcon().deposit(player.getUniqueId(), fee);
-								}
-							}
+							plugin.getEcon().deposit(Bukkit.getOfflinePlayer(plugin.getConfig().getString("tax-account")).getUniqueId(), fee);
 						} catch (Exception e) {
 							e.getMessage();
 							plugin.getLogger().log(Level.WARNING,

--- a/src/main/java/org/maxgamer/quickshop/Shop/ShopManager.java
+++ b/src/main/java/org/maxgamer/quickshop/Shop/ShopManager.java
@@ -635,11 +635,7 @@ public class ShopManager {
 					return;
 				}
 				try {
-					for (OfflinePlayer player : Bukkit.getOfflinePlayers()) {
-						if (player.getName().equals(plugin.getConfig().getString("tax-account"))) {
-							plugin.getEcon().deposit(player.getUniqueId(), tax);
-						}
-					}
+					plugin.getEcon().deposit(Bukkit.getOfflinePlayer(plugin.getConfig().getString("tax-account")).getUniqueId(), tax);
 				} catch (Exception e2) {
 					e2.printStackTrace();
 					plugin.getLogger().log(Level.WARNING,


### PR DESCRIPTION
I switched very recently to QuickShop - thank you so much for your awesome work! - and wondered why the first shop which is created after a server restart does cause a huge timeout of the server. I looked into the dump paperspigot provided and then looked into the code. Since this is the only two times (?) you loop through all offline players on the main thread and it wasn't a issue on my test system instead only on my main server. I assume my database of over 45k offline player files did break this. First I thought there is no simple solution until I looked up how you did it different on other cases. 

Tested this code on my main server. Works fine.


**Timings after the lag spike**
![2133](https://user-images.githubusercontent.com/1338326/53057325-3e42d800-34af-11e9-9dee-da22f0686043.png)

**Server thread dump while the lag spike**
```
[10:19:51] [Paper Watchdog Thread/ERROR]: --- DO NOT REPORT THIS TO PAPER - THIS IS NOT A BUG OR A CRASH  - git-Paper-524 (MC: 1.13.2) ---
[10:19:51] [Paper Watchdog Thread/ERROR]: The server has not responded for 10 seconds! Creating thread dump
[10:19:51] [Paper Watchdog Thread/ERROR]: ------------------------------
[10:19:51] [Paper Watchdog Thread/ERROR]: Server thread dump (Look for plugins here before reporting to Paper!):
[10:19:51] [Paper Watchdog Thread/ERROR]: ------------------------------
[10:19:51] [Paper Watchdog Thread/ERROR]: Current Thread: Server thread
[10:19:51] [Paper Watchdog Thread/ERROR]: 	PID: 20 | Suspended: false | Native: true | State: RUNNABLE
[10:19:51] [Paper Watchdog Thread/ERROR]: 	Stack:
[10:19:51] [Paper Watchdog Thread/ERROR]: 		java.io.FileInputStream.read0(Native Method)
[10:19:51] [Paper Watchdog Thread/ERROR]: 		java.io.FileInputStream.read(FileInputStream.java:207)
[10:19:51] [Paper Watchdog Thread/ERROR]: 		java.util.zip.CheckedInputStream.read(CheckedInputStream.java:59)
[10:19:51] [Paper Watchdog Thread/ERROR]: 		java.util.zip.GZIPInputStream.readUByte(GZIPInputStream.java:266)
[10:19:51] [Paper Watchdog Thread/ERROR]: 		java.util.zip.GZIPInputStream.readUShort(GZIPInputStream.java:258)
[10:19:51] [Paper Watchdog Thread/ERROR]: 		java.util.zip.GZIPInputStream.readHeader(GZIPInputStream.java:164)
[10:19:51] [Paper Watchdog Thread/ERROR]: 		java.util.zip.GZIPInputStream.<init>(GZIPInputStream.java:79)
[10:19:51] [Paper Watchdog Thread/ERROR]: 		java.util.zip.GZIPInputStream.<init>(GZIPInputStream.java:91)
[10:19:51] [Paper Watchdog Thread/ERROR]: 		net.minecraft.server.v1_13_R2.NBTCompressedStreamTools.a(NBTCompressedStreamTools.java:18)
[10:19:51] [Paper Watchdog Thread/ERROR]: 		net.minecraft.server.v1_13_R2.WorldNBTStorage.getPlayerData(WorldNBTStorage.java:271)
[10:19:51] [Paper Watchdog Thread/ERROR]: 		org.bukkit.craftbukkit.v1_13_R2.CraftOfflinePlayer.getData(CraftOfflinePlayer.java:188)
[10:19:51] [Paper Watchdog Thread/ERROR]: 		org.bukkit.craftbukkit.v1_13_R2.CraftOfflinePlayer.getBukkitData(CraftOfflinePlayer.java:192)
[10:19:51] [Paper Watchdog Thread/ERROR]: 		org.bukkit.craftbukkit.v1_13_R2.CraftOfflinePlayer.getName(CraftOfflinePlayer.java:58)
[10:19:51] [Paper Watchdog Thread/ERROR]: 		org.maxgamer.quickshop.Shop.ShopManager.actionCreate(ShopManager.java:639)
[10:19:51] [Paper Watchdog Thread/ERROR]: 		org.maxgamer.quickshop.Shop.ShopManager.access$000(ShopManager.java:34)
[10:19:51] [Paper Watchdog Thread/ERROR]: 		org.maxgamer.quickshop.Shop.ShopManager$1.run(ShopManager.java:368)
[10:19:51] [Paper Watchdog Thread/ERROR]: 		org.bukkit.craftbukkit.v1_13_R2.scheduler.CraftTask.run(CraftTask.java:82)
[10:19:51] [Paper Watchdog Thread/ERROR]: 		org.bukkit.craftbukkit.v1_13_R2.scheduler.CraftScheduler.mainThreadHeartbeat(CraftScheduler.java:449)
[10:19:51] [Paper Watchdog Thread/ERROR]: 		net.minecraft.server.v1_13_R2.MinecraftServer.b(MinecraftServer.java:1003)
[10:19:51] [Paper Watchdog Thread/ERROR]: 		net.minecraft.server.v1_13_R2.DedicatedServer.b(DedicatedServer.java:439)
[10:19:51] [Paper Watchdog Thread/ERROR]: 		net.minecraft.server.v1_13_R2.MinecraftServer.a(MinecraftServer.java:938)
[10:19:51] [Paper Watchdog Thread/ERROR]: 		net.minecraft.server.v1_13_R2.MinecraftServer.run(MinecraftServer.java:836)
[10:19:51] [Paper Watchdog Thread/ERROR]: 		java.lang.Thread.run(Thread.java:748)
[10:19:51] [Paper Watchdog Thread/ERROR]: ------------------------------
```