### PR TITLE
Lazy encoding debug string + Improve action clearing

### DIFF
--- a/src/main/java/org/maxgamer/quickshop/Database/SQLiteCore.java
+++ b/src/main/java/org/maxgamer/quickshop/Database/SQLiteCore.java
@@ -86,7 +86,7 @@ public class SQLiteCore implements DatabaseCore {
 					ps.close();
 				} catch (SQLException e) {
 					Util.debugLog("WARN: A SQL exception happed! Print debug logs...");
-					Util.debugLog("SQL BufferStatement: "+bs.toString());
+					Util.debugLog("SQL BufferStatement: {}", bs);
 					e.printStackTrace();
 
 				}

--- a/src/main/java/org/maxgamer/quickshop/Listeners/DisplayProtectionListener.java
+++ b/src/main/java/org/maxgamer/quickshop/Listeners/DisplayProtectionListener.java
@@ -45,7 +45,7 @@ public class DisplayProtectionListener implements Listener {
 					is.setAmount(0);
 					is.setType(Material.AIR);
 					event.getPlayer().closeInventory();
-					Util.debugLog("Something trying collect QuickShop displayItem, already cancelled. ("+event.getPlayer().getLocation().toString()+")");
+					Util.debugLog("Something trying collect QuickShop displayItem, already cancelled. ({})", event.getPlayer().getLocation());
 					Util.inventoryCheck(event.getInventory());
 				}
 			} catch (Exception e) {}
@@ -60,14 +60,14 @@ public class DisplayProtectionListener implements Listener {
 				e.getPlayer().getInventory().setItemInMainHand(new ItemStack(Material.AIR,0));
 				// You shouldn't be able to pick up that...
 				MsgUtil.sendExploitAlert(e.getPlayer() ,"Player Inventory Scan", e.getPlayer().getLocation());
-				Util.debugLog("Something trying collect QuickShop displayItem, already cancelled. ("+e.getPlayer().getLocation().toString()+")");
+				Util.debugLog("Something trying collect QuickShop displayItem, already cancelled. ({})", e.getPlayer().getLocation());
 				Util.inventoryCheck(e.getPlayer().getInventory());
 			}
 			if (DisplayItem.checkShopItem(stackOffHand)) {
 				e.getPlayer().getInventory().setItemInOffHand(new ItemStack(Material.AIR,0));
 				// You shouldn't be able to pick up that...
 				MsgUtil.sendExploitAlert(e.getPlayer() ,"Player Inventory Scan", e.getPlayer().getLocation());
-				Util.debugLog("Something trying collect QuickShop displayItem, already cancelled. ("+e.getPlayer().getLocation().toString()+")");
+				Util.debugLog("Something trying collect QuickShop displayItem, already cancelled. ({})", e.getPlayer().getLocation());
 				Util.inventoryCheck(e.getPlayer().getInventory());
 			}
 		} catch (NullPointerException ex) {
@@ -83,14 +83,14 @@ public class DisplayProtectionListener implements Listener {
 				e.getPlayer().getInventory().setItemInMainHand(new ItemStack(Material.AIR,0));
 				// You shouldn't be able to pick up that...
 				MsgUtil.sendExploitAlert(e.getPlayer() ,"Player Inventory Scan", e.getPlayer().getLocation());
-				Util.debugLog("Something trying collect QuickShop displayItem, already cancelled. ("+e.getPlayer().getLocation().toString()+")");
+				Util.debugLog("Something trying collect QuickShop displayItem, already cancelled. ({})", e.getPlayer().getLocation());
 				Util.inventoryCheck(e.getPlayer().getInventory());
 			}
 			if (DisplayItem.checkShopItem(stackOffHand)) {
 				e.getPlayer().getInventory().setItemInOffHand(new ItemStack(Material.AIR,0));
 				// You shouldn't be able to pick up that...
 				MsgUtil.sendExploitAlert(e.getPlayer() ,"Player Inventory Scan", e.getPlayer().getLocation());
-				Util.debugLog("Something trying collect QuickShop displayItem, already cancelled. ("+e.getPlayer().getLocation().toString()+")");
+				Util.debugLog("Something trying collect QuickShop displayItem, already cancelled. ({})", e.getPlayer().getLocation());
 				Util.inventoryCheck(e.getPlayer().getInventory());
 			}
 		} catch (NullPointerException ex) {
@@ -105,14 +105,14 @@ public class DisplayProtectionListener implements Listener {
 				e.getPlayer().getInventory().setItemInMainHand(new ItemStack(Material.AIR,0));
 				// You shouldn't be able to pick up that...
 				MsgUtil.sendExploitAlert(e.getPlayer() ,"Player Inventory Scan", e.getPlayer().getLocation());
-				Util.debugLog("Something trying collect QuickShop displayItem, already cancelled. ("+e.getPlayer().getLocation().toString()+")");
+				Util.debugLog("Something trying collect QuickShop displayItem, already cancelled. ({})", e.getPlayer().getLocation());
 				Util.inventoryCheck(e.getPlayer().getInventory());
 			}
 			if (DisplayItem.checkShopItem(stackOffHand)) {
 				e.getPlayer().getInventory().setItemInOffHand(new ItemStack(Material.AIR,0));
 				// You shouldn't be able to pick up that...
 				MsgUtil.sendExploitAlert(e.getPlayer() ,"Player Inventory Scan", e.getPlayer().getLocation());
-				Util.debugLog("Something trying collect QuickShop displayItem, already cancelled. ("+e.getPlayer().getLocation().toString()+")");
+				Util.debugLog("Something trying collect QuickShop displayItem, already cancelled. ({})", e.getPlayer().getLocation());
 				Util.inventoryCheck(e.getPlayer().getInventory());
 			}
 		} catch (NullPointerException ex) {
@@ -125,7 +125,7 @@ public class DisplayProtectionListener implements Listener {
 		try {
 			if (DisplayItem.checkShopItem(stack)) {
 				e.setCancelled(true);
-				Util.debugLog("Something trying collect QuickShop displayItem, already cancelled. ("+e.getEntity().getLocation().toString()+")");
+				Util.debugLog("Something trying collect QuickShop displayItem, already cancelled. ({})", e.getEntity().getLocation());
 				// You shouldn't be able to pick up that...
 				e.getItem().remove();
 				e.getEntity().setCanPickupItems(false);
@@ -156,7 +156,7 @@ public class DisplayProtectionListener implements Listener {
 			if(found) {
 				e.setCancelled(true);
 				MsgUtil.sendExploitAlert(e.getPlayer() ,"Player Interact", e.getPlayer().getLocation());
-				Util.debugLog("Something trying collect QuickShop displayItem, already cancelled. ("+e.getPlayer().getInventory().getLocation().toString()+")");
+				Util.debugLog("Something trying collect QuickShop displayItem, already cancelled. ({})", e.getPlayer().getInventory().getLocation());
 				Util.inventoryCheck(e.getPlayer().getInventory());
 			}
 		} catch (NullPointerException ex) {
@@ -172,7 +172,7 @@ public class DisplayProtectionListener implements Listener {
 				event.getCurrentItem().setAmount(0);
 				event.getCurrentItem().setType(Material.AIR);
 				event.setResult(Result.DENY);
-				Util.debugLog("Something trying collect QuickShop displayItem, already cancelled. ("+event.getInventory().getLocation().toString()+")");
+				Util.debugLog("Something trying collect QuickShop displayItem, already cancelled. ({})", event.getInventory().getLocation());
 				Util.inventoryCheck(event.getInventory());
 			}
 			if(itemStackCheck(event.getCursor())) {
@@ -181,7 +181,7 @@ public class DisplayProtectionListener implements Listener {
 				event.getCursor().setAmount(0);
 				event.getCursor().setType(Material.AIR);
 				event.setResult(Result.DENY);
-				Util.debugLog("Something trying collect QuickShop displayItem, already cancelled. ("+event.getInventory().getLocation().toString()+")");
+				Util.debugLog("Something trying collect QuickShop displayItem, already cancelled. ({})", event.getInventory().getLocation());
 				Util.inventoryCheck(event.getInventory());
 			}
 			
@@ -197,7 +197,7 @@ public class DisplayProtectionListener implements Listener {
 //				plugin.getLogger().warning("[Exploit alert] Inventory "+event.getInventory().getName()+" at "+event.getItem().getLocation()+" picked up display item "+is);
 //				Util.sendMessageToOps(ChatColor.RED+"[QuickShop][Exploit alert] Inventory "+event.getView().getTitle()+" at "+event.getItem().getLocation()+" picked up display item "+is);
 				MsgUtil.sendExploitAlert(event.getInventory(),"Pickup DisplayItem", event.getInventory().getLocation());
-				Util.debugLog("Something trying collect QuickShop displayItem, already cancelled. ("+event.getInventory().getLocation().toString()+")");
+				Util.debugLog("Something trying collect QuickShop displayItem, already cancelled. ({})", event.getInventory().getLocation());
 				event.getItem().remove();
 				Util.inventoryCheck(event.getInventory());
 			}

--- a/src/main/java/org/maxgamer/quickshop/Listeners/PlayerListener.java
+++ b/src/main/java/org/maxgamer/quickshop/Listeners/PlayerListener.java
@@ -179,30 +179,19 @@ public class PlayerListener implements Listener {
 	 * Waits for a player to move too far from a shop, then cancels the menu.
 	 */
 	public void onMove(PlayerMoveEvent e) {
-		if (e.isCancelled())
-			return;
-		Info info = plugin.getShopManager().getActions().get(e.getPlayer().getUniqueId());
-		if (info != null) {
-			Player p = e.getPlayer();
-			Location loc1 = info.getLocation();
-			Location loc2 = p.getLocation();
-			if (loc1.getWorld() != loc2.getWorld() || loc1.distanceSquared(loc2) > 25) {
-				if (info.getAction() == ShopAction.CREATE) {
-					p.sendMessage(MsgUtil.getMessage("shop-creation-cancelled"));
-				} else if (info.getAction() == ShopAction.BUY) {
-					p.sendMessage(MsgUtil.getMessage("shop-purchase-cancelled"));
-				}
-				plugin.getShopManager().getActions().remove(p.getUniqueId());
-				return;
-			}
-		}
+	    // Only check when meeting `actual` move
+	    if (Util.isCoordinateChanged(e.getFrom(), e.getTo()))
+	        Util.cancelInvaildActionAndNotifyFor(e.getPlayer());
 	}
 
 	@EventHandler(ignoreCancelled=true)
 	public void onTeleport(PlayerTeleportEvent e) {
-		PlayerMoveEvent me = new PlayerMoveEvent(e.getPlayer(), e.getFrom(), e.getTo());
-		onMove(me);
-		Util.inventoryCheck(e.getPlayer().getInventory());
+	    Player player = e.getPlayer();
+	    // Only check when meeting coord-changing teleport
+        if (Util.isCoordinateChanged(e.getFrom(), e.getTo()))
+            Util.cancelInvaildActionAndNotifyFor(player);
+        
+		Util.inventoryCheck(player.getInventory());
 	}
 
 	@EventHandler(ignoreCancelled=true)

--- a/src/main/java/org/maxgamer/quickshop/QuickShop.java
+++ b/src/main/java/org/maxgamer/quickshop/QuickShop.java
@@ -266,7 +266,7 @@ public class QuickShop extends JavaPlugin {
 						if(world==null){
 							// Still load failed? It removed or not got loaded now?
 							skipedShops++;
-							Util.debugLog("Found a shop can't match shop's world: "+worldName+", it got removed or just not loaded? Ignore it...");
+							Util.debugLog("Found a shop can't match shop's world: {}, it got removed or just not loaded? Ignore it...", worldName);
 							continue;
 						}
 					}

--- a/src/main/java/org/maxgamer/quickshop/Shop/ContainerShop.java
+++ b/src/main/java/org/maxgamer/quickshop/Shop/ContainerShop.java
@@ -184,7 +184,7 @@ public class ContainerShop implements Shop {
 	public void setPrice(double price) {
 		this.price = price;
 		update();
-		Util.debugLog("New price is applyed to shop: "+String.valueOf(price));
+		Util.debugLog("New price is applyed to shop: {}", price);
 	}
 
 	/**
@@ -427,7 +427,7 @@ public class ContainerShop implements Shop {
 	public void setOwner(UUID owner) {
 		this.owner = owner;
 		update();
-		Util.debugLog("New owner is applyed to shop: "+owner.toString());
+		Util.debugLog("New owner is applyed to shop: {}", owner);
 	}
 
 	/**
@@ -442,7 +442,7 @@ public class ContainerShop implements Shop {
 	public void setUnlimited(boolean unlimited) {
 		this.unlimited = unlimited;
 		update();
-		Util.debugLog("New unlimited mode is applyed to shop: "+String.valueOf(unlimited));
+		Util.debugLog("New unlimited mode is applyed to shop: {}", unlimited);
 	}
 
 	public boolean isUnlimited() {
@@ -471,7 +471,7 @@ public class ContainerShop implements Shop {
 		this.shopType = shopType;
 		this.setSignText();
 		update();
-		Util.debugLog("New shopType is applyed to shop: "+shopType.toString());
+		Util.debugLog("New shopType is applyed to shop: {}", shopType);
 	}
 
 	/**
@@ -502,7 +502,7 @@ public class ContainerShop implements Shop {
 		lines[3] = MsgUtil.getMessage("signs.price", Util.format(this.getPrice()));
 		this.setSignText(lines);
 		Util.debugLog("New sign was setuped.");
-		Util.debugLog(lines.toString());
+		Util.debugLog(lines);
 	}
 
 	/**

--- a/src/main/java/org/maxgamer/quickshop/Util/Paste.java
+++ b/src/main/java/org/maxgamer/quickshop/Util/Paste.java
@@ -97,7 +97,7 @@ public class Paste {
         out.print(builder.toString());
         out.flush();//Drop
         BufferedReader in = new BufferedReader(new InputStreamReader(conn.getInputStream()));
-        Util.debugLog("Request Completed: "+conn.getURL().toString());
+        Util.debugLog("Request Completed: {}", conn.getURL());
         String link = conn.getURL().toString();
         if(in!=null)
             in.close();

--- a/src/main/java/org/maxgamer/quickshop/Util/Util.java
+++ b/src/main/java/org/maxgamer/quickshop/Util/Util.java
@@ -940,7 +940,11 @@ public class Util {
     public static void debugLog(Object log, Object... params)    {
         if(devMode) {
             int index = 0;
-            plugin.getLogger().warning("[DEBUG] " + StringUtils.replace(log.toString(), "{}", params[index++].toString()));
+            
+            for (Object param : params)
+                log = StringUtils.replace(log.toString(), "{}", params[index++].toString());
+            
+            plugin.getLogger().warning(log.toString());
         }
     }
     

--- a/src/main/java/org/maxgamer/quickshop/Util/Util.java
+++ b/src/main/java/org/maxgamer/quickshop/Util/Util.java
@@ -940,7 +940,7 @@ public class Util {
     public static void debugLog(Object log, Object... params)    {
         if(devMode) {
             for (int index = 0; index < params.length; index++)
-                log = StringUtils.replaceOnce(log.toString(), "{}", params[index++].toString());
+                log = StringUtils.replaceOnce(log.toString(), "{}", params[index].toString());
             
             plugin.getLogger().warning(log.toString());
         }

--- a/src/main/java/org/maxgamer/quickshop/Util/Util.java
+++ b/src/main/java/org/maxgamer/quickshop/Util/Util.java
@@ -939,10 +939,8 @@ public class Util {
      */
     public static void debugLog(Object log, Object... params)    {
         if(devMode) {
-            int index = 0;
-            
-            for (Object param : params)
-                log = StringUtils.replace(log.toString(), "{}", params[index++].toString());
+            for (int index = 0; index < params.length; index++)
+                log = StringUtils.replaceOnce(log.toString(), "{}", params[index++].toString());
             
             plugin.getLogger().warning(log.toString());
         }


### PR DESCRIPTION
* Ignore non-coord changed moving/teleport to avoid useless performance cost, by adding one more helper method to check coordinate.
* Move action clearing codes to `Util` to improve code quality and readability.
* Lazy `toString` to avoid useless performance cost under non-dev mode, by adding one more helper method with variable arguments.

**Performance note about variable arguments** No extra performance impact under non-dev mode since we don't look up the array.