### PR TITLE
Fix item display name

### DIFF
--- a/src/main/java/org/maxgamer/quickshop/Shop/RealDisplayItem.java
+++ b/src/main/java/org/maxgamer/quickshop/Shop/RealDisplayItem.java
@@ -185,6 +185,7 @@ public class RealDisplayItem implements DisplayItem {
         this.item.setSilent(true);
         this.item.setPortalCooldown(Integer.MAX_VALUE);
         this.item.setVelocity(new Vector(0, 0.1, 0));
+        this.item.setCustomNameVisible(false);
         safeGuard(this.item);
         Util.debugLog("Spawned new DisplayItem for shop " + shop.getLocation().toString());
     }


### PR DESCRIPTION
Remove item display name as it would be annoying (usually added on drops by holograms drops plugins)