### PR TITLE
Better version checks, Close GH-308

### DIFF
--- a/src/main/java/org/maxgamer/quickshop/Watcher/UpdateWatcher.java
+++ b/src/main/java/org/maxgamer/quickshop/Watcher/UpdateWatcher.java
@@ -46,6 +46,29 @@ public class UpdateWatcher implements Listener {
     originalVer = originalVer.trim();
     return originalVer;
   }
+  
+  // Match *.*.*, where * is a number from 0 to 9
+  private static final Pattern VERSION_PATTERN = Pattern.compile("\\d+\\.\\d+\\.\\d+");
+  
+  private static boolean isHigherVersion(@NotNull String current, @NotNull String test) {
+    Matcher currentMatcher = VERSION_PATTERN.matcher(current);
+    Matcher testMatcher    = VERSION_PATTERN.matcher(test);
+    if (!currentMatcher.find() || !testMatcher.find())
+      return true;
+    
+    String[] currentVers = currentMatcher.group().split("\\.");
+    String[] testVers    = testMatcher.group().split("\\.");
+    
+    for (int i = 0; i < Math.min(currentVers.length, testVers.length); i++) {
+      int currentVer = NumberUtils.toInt(currentVers[i]), testVer = NumberUtils.toInt(testVers[i]);
+      if (testVer > currentVer)
+        return true;
+      else if (currentVer > testVer)
+        return false;
+    }
+    
+    return testVers.length > currentVers.length;
+  }
 
   public static void init() {
     cronTask =
@@ -60,7 +83,7 @@ public class UpdateWatcher implements Listener {
               return;
             }
 
-            if (info.getVersion().equals(QuickShop.getVersion())) {
+            if (!isHigherVersion(QuickShop.getVersion(), info.getVersion())) {
               hasNewUpdate = false;
               return;
             }

--- a/src/main/java/org/maxgamer/quickshop/Watcher/UpdateWatcher.java
+++ b/src/main/java/org/maxgamer/quickshop/Watcher/UpdateWatcher.java
@@ -47,7 +47,7 @@ public class UpdateWatcher implements Listener {
     return originalVer;
   }
   
-  // Match *.*.*, where * is a number from 0 to 9
+  // Match *.*.*, where * is numbers
   private static final Pattern VERSION_PATTERN = Pattern.compile("\\d+\\.\\d+\\.\\d+");
   
   private static boolean isHigherVersion(@NotNull String current, @NotNull String test) {

--- a/src/main/java/org/maxgamer/quickshop/Watcher/UpdateWatcher.java
+++ b/src/main/java/org/maxgamer/quickshop/Watcher/UpdateWatcher.java
@@ -21,6 +21,8 @@ package org.maxgamer.quickshop.Watcher;
 
 import java.util.List;
 import java.util.Random;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import net.md_5.bungee.api.chat.ClickEvent;
 import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.Bukkit;
@@ -35,6 +37,7 @@ import org.maxgamer.quickshop.QuickShop;
 import org.maxgamer.quickshop.Util.MsgUtil;
 import org.maxgamer.quickshop.Util.UpdateInfomation;
 import org.maxgamer.quickshop.Util.Updater;
+import org.apache.commons.lang.math.NumberUtils;
 
 public class UpdateWatcher implements Listener {
   public static boolean hasNewUpdate = false;
@@ -47,7 +50,7 @@ public class UpdateWatcher implements Listener {
     return originalVer;
   }
   
-  // Match *.*.*, where * is numbers
+  // Match *.*.*, where * are numbers
   private static final Pattern VERSION_PATTERN = Pattern.compile("\\d+\\.\\d+\\.\\d+");
   
   private static boolean isHigherVersion(@NotNull String current, @NotNull String test) {


### PR DESCRIPTION
This matches version in format *.*.* from a string, where * is a sub-version number, and compare two versions from the left to the right.

This return `false` if two versions are the same, or current version has more sub-version than the other one, such as 2.3.1.1 (local) > 2.3.1 (remote).

And will always return `true` if the matching fails so the user won't missing an update.