### PR TITLE
Address Issue #807 (Only use a single item and center it for a double chest buy/sell shop.)

### DIFF
--- a/src/main/java/org/maxgamer/quickshop/shop/ContainerShop.java
+++ b/src/main/java/org/maxgamer/quickshop/shop/ContainerShop.java
@@ -164,7 +164,7 @@ public class ContainerShop implements Shop {
                 displayItem.remove();
             }
             // Don't make an item for this chest if it's a left shop.
-            if (isRealDouble() && isLeftShop()
+            if (isLeftShop()
                 && Objects.requireNonNull(getAttachedShop()).getDisplayItem() != null) {
                 getAttachedShop().refresh();
                 return;
@@ -1260,6 +1260,9 @@ public class ContainerShop implements Shop {
     @Override
     public boolean isLeftShop() {
         if (getAttachedShop() == null) {
+            return false;
+        }
+        if (!isRealDouble()) {
             return false;
         }
 

--- a/src/main/java/org/maxgamer/quickshop/shop/ContainerShop.java
+++ b/src/main/java/org/maxgamer/quickshop/shop/ContainerShop.java
@@ -31,6 +31,7 @@ import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.Sign;
+import org.bukkit.block.data.type.Chest;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
@@ -1266,19 +1267,19 @@ public class ContainerShop implements Shop {
             return false;
         }
 
-        float yaw = getLocation().getYaw();
-        if (yaw == 0) {
-            // left block has a smaller x value
-            return getLocation().getX() < getAttachedShop().getLocation().getX();
-        } else if (yaw == 180) {
-            // left block has greater x value
-            return getLocation().getX() > getAttachedShop().getLocation().getX();
-        } else if (yaw > 45 && yaw < 135) {
-            // left block has a smaller z value
-            return getLocation().getZ() < getAttachedShop().getLocation().getZ();
-        } else if (yaw > 225 && yaw < 315) {
-            // left block has a greater z value
-            return getLocation().getZ() > getAttachedShop().getLocation().getZ();
+        switch (((Chest) getLocation().getBlock().getBlockData()).getFacing()) {
+            case WEST:
+                // left block has a smaller z value
+                return getLocation().getZ() < getAttachedShop().getLocation().getZ();
+            case EAST:
+                // left block has a greater z value
+                return getLocation().getZ() > getAttachedShop().getLocation().getZ();
+            case NORTH:
+                // left block has greater x value
+                return getLocation().getX() > getAttachedShop().getLocation().getX();
+            case SOUTH:
+                // left block has a smaller x value
+                return getLocation().getX() < getAttachedShop().getLocation().getX();
         }
         return false;
     }

--- a/src/main/java/org/maxgamer/quickshop/shop/ContainerShop.java
+++ b/src/main/java/org/maxgamer/quickshop/shop/ContainerShop.java
@@ -1305,6 +1305,8 @@ public class ContainerShop implements Shop {
                 // left block has a smaller x value
                 isLeftShop = getLocation().getX() < attachedShop.getLocation().getX();
                 break;
+            default:
+                isLeftShop = false;
         }
     }
 

--- a/src/main/java/org/maxgamer/quickshop/shop/ContainerShop.java
+++ b/src/main/java/org/maxgamer/quickshop/shop/ContainerShop.java
@@ -55,6 +55,7 @@ import java.util.logging.Level;
  */
 @EqualsAndHashCode
 public class ContainerShop implements Shop {
+
     private static final String shopSignPrefix = "§d§o §r";
     private static final String shopSignPattern = "§d§o ";
     @NotNull
@@ -103,13 +104,13 @@ public class ContainerShop implements Shop {
     }
 
     /**
-     * Adds a new shop.
-     * You need call ShopManager#loadShop if you create from outside of ShopLoader.
+     * Adds a new shop. You need call ShopManager#loadShop if you create from outside of
+     * ShopLoader.
      *
      * @param location  The location of the chest block
      * @param price     The cost per item
-     * @param item      The itemstack with the properties we want. This is .cloned, no need to worry about
-     *                  references
+     * @param item      The itemstack with the properties we want. This is .cloned, no need to worry
+     *                  about references
      * @param moderator The modertators
      * @param type      The shop type
      * @param unlimited The unlimited
@@ -117,14 +118,14 @@ public class ContainerShop implements Shop {
      * @param extra     The extra data saved by addon
      */
     public ContainerShop(
-            @NotNull QuickShop plugin,
-            @NotNull Location location,
-            double price,
-            @NotNull ItemStack item,
-            @NotNull ShopModerator moderator,
-            boolean unlimited,
-            @NotNull ShopType type,
-            @NotNull Map<String, Map<String, Object>> extra) {
+        @NotNull QuickShop plugin,
+        @NotNull Location location,
+        double price,
+        @NotNull ItemStack item,
+        @NotNull ShopModerator moderator,
+        boolean unlimited,
+        @NotNull ShopType type,
+        @NotNull Map<String, Map<String, Object>> extra) {
         Util.ensureThread(false);
         this.location = location;
         this.price = price;
@@ -140,7 +141,8 @@ public class ContainerShop implements Shop {
                 Util.debugLog("Shop item display is: " + meta.getDisplayName());
                 //https://hub.spigotmc.org/jira/browse/SPIGOT-5964
                 if (meta.getDisplayName().matches("\\{.*\\}")) {
-                    meta.setDisplayName(LegacyComponentSerializer.legacySection().serialize(GsonComponentSerializer.gson().deserialize(meta.getDisplayName())));
+                    meta.setDisplayName(LegacyComponentSerializer.legacySection().serialize(
+                        GsonComponentSerializer.gson().deserialize(meta.getDisplayName())));
                     //Correct both items
                     item.setItemMeta(meta);
                     this.item.setItemMeta(meta);
@@ -158,10 +160,20 @@ public class ContainerShop implements Shop {
     private void initDisplayItem() {
         Util.ensureThread(false);
         if (plugin.isDisplay()) {
+            if (displayItem != null) {
+                displayItem.remove();
+            }
+            // Don't make an item for this chest if it's a left shop.
+            if (isRealDouble() && isLeftShop()
+                && Objects.requireNonNull(getAttachedShop()).getDisplayItem() != null) {
+                getAttachedShop().refresh();
+                return;
+            }
+
             switch (DisplayItem.getNowUsing()) {
                 case UNKNOWN:
                     Util.debugLog(
-                            "Failed to create a ContainerShop displayItem, the type is unknown, fallback to RealDisplayItem");
+                        "Failed to create a ContainerShop displayItem, the type is unknown, fallback to RealDisplayItem");
                     this.displayItem = new RealDisplayItem(this);
                     break;
                 case REALITEM:
@@ -172,8 +184,10 @@ public class ContainerShop implements Shop {
                     break;
                 case VIRTUALITEM:
                     try {
-                        if (!GameVersion.get(ReflectFactory.getServerVersion()).isVirtualDisplaySupports()) {
-                            throw new IllegalStateException("Version not supports Virtual DisplayItem.");
+                        if (!GameVersion.get(ReflectFactory.getServerVersion())
+                            .isVirtualDisplaySupports()) {
+                            throw new IllegalStateException(
+                                "Version not supports Virtual DisplayItem.");
                         }
                         this.displayItem = new VirtualDisplayItem(this);
 
@@ -185,12 +199,14 @@ public class ContainerShop implements Shop {
                         plugin.saveConfig();
                         this.displayItem = new RealDisplayItem(this);
                         //do not throw
-                        plugin.getLogger().log(Level.SEVERE, "Failed to initialize VirtualDisplayItem, fallback to RealDisplayItem, are you using the latest version of ProtocolLib?", e);
+                        plugin.getLogger().log(Level.SEVERE,
+                            "Failed to initialize VirtualDisplayItem, fallback to RealDisplayItem, are you using the latest version of ProtocolLib?",
+                            e);
                     }
                     break;
                 default:
                     Util.debugLog(
-                            "Warning: Failed to create a ContainerShop displayItem, the type we didn't know, fallback to RealDisplayItem");
+                        "Warning: Failed to create a ContainerShop displayItem, the type we didn't know, fallback to RealDisplayItem");
                     this.displayItem = new RealDisplayItem(this);
                     break;
             }
@@ -232,7 +248,8 @@ public class ContainerShop implements Shop {
         boolean result = this.moderator.addStaff(player);
         update();
         if (result) {
-            Util.mainThreadRun(() -> plugin.getServer().getPluginManager().callEvent(new ShopModeratorChangedEvent(this, this.moderator)));
+            Util.mainThreadRun(() -> plugin.getServer().getPluginManager()
+                .callEvent(new ShopModeratorChangedEvent(this, this.moderator)));
         }
         return result;
     }
@@ -246,7 +263,8 @@ public class ContainerShop implements Shop {
      * @param amount         The amount to buy
      */
     @Override
-    public void buy(@NotNull UUID buyer, @NotNull Inventory buyerInventory, @NotNull Location loc2Drop, int amount) {
+    public void buy(@NotNull UUID buyer, @NotNull Inventory buyerInventory,
+        @NotNull Location loc2Drop, int amount) {
         Util.ensureThread(false);
         amount = amount * item.getAmount();
         if (amount < 0) {
@@ -271,16 +289,16 @@ public class ContainerShop implements Shop {
             // This should not happen.
             if (amount > 0) {
                 plugin
-                        .getLogger()
-                        .log(
-                                Level.WARNING,
-                                "Could not take all items from a players inventory on purchase! "
-                                        + buyer
-                                        + ", missing: "
-                                        + amount
-                                        + ", item: "
-                                        + Util.getItemStackName(this.getItem())
-                                        + "!");
+                    .getLogger()
+                    .log(
+                        Level.WARNING,
+                        "Could not take all items from a players inventory on purchase! "
+                            + buyer
+                            + ", missing: "
+                            + amount
+                            + ", item: "
+                            + Util.getItemStackName(this.getItem())
+                            + "!");
             }
         } else {
             Inventory chestInv = this.getInventory();
@@ -312,7 +330,8 @@ public class ContainerShop implements Shop {
     @Override
     public void checkDisplay() {
         Util.ensureThread(false);
-        if (!plugin.isDisplay() || !this.isLoaded || this.isDeleted()) { // FIXME: Reinit scheduler on reloading config
+        if (!plugin.isDisplay() || !this.isLoaded || this
+            .isDeleted()) { // FIXME: Reinit scheduler on reloading config
             return;
         }
 
@@ -320,19 +339,19 @@ public class ContainerShop implements Shop {
             Util.debugLog("Warning: DisplayItem is null, this shouldn't happened...");
             StackTraceElement traceElements = Thread.currentThread().getStackTrace()[2];
             Util.debugLog(
-                    "Call from: "
-                            + traceElements.getClassName()
-                            + "#"
-                            + traceElements.getMethodName()
-                            + "%"
-                            + traceElements.getLineNumber());
+                "Call from: "
+                    + traceElements.getClassName()
+                    + "#"
+                    + traceElements.getMethodName()
+                    + "%"
+                    + traceElements.getLineNumber());
             return;
         }
 
         if (!this.displayItem.isSpawned()) {
             /* Not spawned yet. */
             //Util.debugLog("Target item not spawned, spawning for shop " + this.getLocation());
-            this.displayItem.spawn();
+            displayItem.spawn();
         } else {
             /* If not spawned, we didn't need check these, only check them when we need. */
             if (this.displayItem.checkDisplayNeedRegen()) {
@@ -354,7 +373,8 @@ public class ContainerShop implements Shop {
     public void clearStaffs() {
         setDirty();
         this.moderator.clearStaffs();
-        Util.mainThreadRun(() -> plugin.getServer().getPluginManager().callEvent(new ShopModeratorChangedEvent(this, this.moderator)));
+        Util.mainThreadRun(() -> plugin.getServer().getPluginManager()
+            .callEvent(new ShopModeratorChangedEvent(this, this.moderator)));
         update();
     }
 
@@ -365,7 +385,8 @@ public class ContainerShop implements Shop {
         boolean result = this.moderator.delStaff(player);
         update();
         if (result) {
-            Util.mainThreadRun(() -> plugin.getServer().getPluginManager().callEvent(new ShopModeratorChangedEvent(this, this.moderator)));
+            Util.mainThreadRun(() -> plugin.getServer().getPluginManager()
+                .callEvent(new ShopModeratorChangedEvent(this, this.moderator)));
         }
         return result;
     }
@@ -387,6 +408,7 @@ public class ContainerShop implements Shop {
     @Override
     public void delete(boolean memoryOnly) {
         Util.ensureThread(false);
+        ContainerShop neighbor = getAttachedShop();
         setDirty();
         ShopDeleteEvent shopDeleteEvent = new ShopDeleteEvent(this, memoryOnly);
         if (Util.fireCancellableEvent(shopDeleteEvent)) {
@@ -401,18 +423,29 @@ public class ContainerShop implements Shop {
         if (memoryOnly) {
             // Delete it from memory
             plugin.getShopManager().removeShop(this);
+            onUnload();
         } else {
             // Delete the signs around it
             for (Sign s : this.getSigns()) {
                 s.getBlock().setType(Material.AIR);
             }
+            if (displayItem != null) {
+                displayItem.remove();
+            }
             // Delete it from the database
             // Refund if necessary
             if (plugin.getConfig().getBoolean("shop.refund")) {
-                plugin.getEconomy().deposit(this.getOwner(), plugin.getConfig().getDouble("shop.cost"), getLocation().getWorld(), getCurrency());
+                plugin.getEconomy()
+                    .deposit(this.getOwner(), plugin.getConfig().getDouble("shop.cost"),
+                        Objects.requireNonNull(getLocation().getWorld()), getCurrency());
             }
             plugin.getShopManager().removeShop(this);
+            onUnload();
             plugin.getDatabaseHelper().removeShop(this);
+        }
+        // Makes sure deleting a shop will fix the item position.
+        if (neighbor != null) {
+            neighbor.refresh();
         }
     }
 
@@ -481,7 +514,7 @@ public class ContainerShop implements Shop {
         String name = player.getName();
         if (name == null || name.isEmpty()) {
             name = MsgUtil.getMessageOfflinePlayer(
-                    "unknown-owner", player);
+                "unknown-owner", player);
         }
         if (forceUsername) {
             return name;
@@ -531,7 +564,8 @@ public class ContainerShop implements Shop {
      * @param amount          The amount to sell
      */
     @Override
-    public void sell(@NotNull UUID seller, @NotNull Inventory sellerInventory, @NotNull Location loc2Drop, int amount) {
+    public void sell(@NotNull UUID seller, @NotNull Inventory sellerInventory,
+        @NotNull Location loc2Drop, int amount) {
         Util.ensureThread(false);
         amount = item.getAmount() * amount;
         if (amount < 0) {
@@ -590,17 +624,21 @@ public class ContainerShop implements Shop {
         if (this.isSelling()) {
             if (this.getItem().getAmount() > 1) {
                 if (this.getRemainingStock() == -1) {
-                    lines[1] = MsgUtil.getMessageOfflinePlayer("signs.stack-selling", player, MsgUtil.getMessageOfflinePlayer("signs.unlimited", player));
+                    lines[1] = MsgUtil.getMessageOfflinePlayer("signs.stack-selling", player,
+                        MsgUtil.getMessageOfflinePlayer("signs.unlimited", player));
                 } else {
                     lines[1] =
-                            MsgUtil.getMessageOfflinePlayer("signs.stack-selling", player, Integer.toString(getRemainingStock()));
+                        MsgUtil.getMessageOfflinePlayer("signs.stack-selling", player,
+                            Integer.toString(getRemainingStock()));
                 }
             } else {
                 if (this.getRemainingStock() == -1) {
-                    lines[1] = MsgUtil.getMessageOfflinePlayer("signs.selling", player, MsgUtil.getMessageOfflinePlayer("signs.unlimited", player));
+                    lines[1] = MsgUtil.getMessageOfflinePlayer("signs.selling", player,
+                        MsgUtil.getMessageOfflinePlayer("signs.unlimited", player));
                 } else {
                     lines[1] =
-                            MsgUtil.getMessageOfflinePlayer("signs.selling", player, Integer.toString(this.getRemainingStock()));
+                        MsgUtil.getMessageOfflinePlayer("signs.selling", player,
+                            Integer.toString(this.getRemainingStock()));
                 }
             }
 
@@ -608,17 +646,21 @@ public class ContainerShop implements Shop {
         } else if (this.isBuying()) {
             if (this.getItem().getAmount() > 1) {
                 if (this.getRemainingSpace() == -1) {
-                    lines[1] = MsgUtil.getMessageOfflinePlayer("signs.stack-buying", player, MsgUtil.getMessageOfflinePlayer("signs.unlimited", player));
+                    lines[1] = MsgUtil.getMessageOfflinePlayer("signs.stack-buying", player,
+                        MsgUtil.getMessageOfflinePlayer("signs.unlimited", player));
                 } else {
                     lines[1] =
-                            MsgUtil.getMessageOfflinePlayer("signs.stack-buying", player, Integer.toString(getRemainingSpace()));
+                        MsgUtil.getMessageOfflinePlayer("signs.stack-buying", player,
+                            Integer.toString(getRemainingSpace()));
                 }
             } else {
                 if (this.getRemainingSpace() == -1) {
-                    lines[1] = MsgUtil.getMessageOfflinePlayer("signs.buying", player, MsgUtil.getMessageOfflinePlayer("signs.unlimited", player));
+                    lines[1] = MsgUtil.getMessageOfflinePlayer("signs.buying", player,
+                        MsgUtil.getMessageOfflinePlayer("signs.unlimited", player));
                 } else {
                     lines[1] =
-                            MsgUtil.getMessageOfflinePlayer("signs.buying", player, Integer.toString(this.getRemainingSpace()));
+                        MsgUtil.getMessageOfflinePlayer("signs.buying", player,
+                            Integer.toString(this.getRemainingSpace()));
                 }
             }
 //            if (this.getRemainingSpace() == -1) {
@@ -633,12 +675,15 @@ public class ContainerShop implements Shop {
 //            }
         }
         lines[2] =
-                MsgUtil.getMessageOfflinePlayer(
-                        "signs.item", player, Util.getItemStackName(this.getItem()));
+            MsgUtil.getMessageOfflinePlayer(
+                "signs.item", player, Util.getItemStackName(this.getItem()));
         if (this.isStackingShop()) {
-            lines[3] = MsgUtil.getMessageOfflinePlayer("signs.stack-price", player, Util.format(this.getPrice(), this), Integer.toString(item.getAmount()), Util.getItemStackName(item));
+            lines[3] = MsgUtil.getMessageOfflinePlayer("signs.stack-price", player,
+                Util.format(this.getPrice(), this), Integer.toString(item.getAmount()),
+                Util.getItemStackName(item));
         } else {
-            lines[3] = MsgUtil.getMessageOfflinePlayer("signs.price", player, Util.format(this.getPrice(), this));
+            lines[3] = MsgUtil
+                .getMessageOfflinePlayer("signs.price", player, Util.format(this.getPrice(), this));
 
         }
         //new pattern
@@ -702,9 +747,13 @@ public class ContainerShop implements Shop {
         String world = Objects.requireNonNull(this.getLocation().getWorld()).getName();
         int unlimited = this.isUnlimited() ? 1 : 0;
         try {
-            plugin.getDatabaseHelper().updateShop(ShopModerator.serialize(this.moderator.clone()), this.getItem(), unlimited, shopType.toID(), this.getPrice(), x, y, z, world, this.saveExtraToJson());
+            plugin.getDatabaseHelper()
+                .updateShop(ShopModerator.serialize(this.moderator.clone()), this.getItem(),
+                    unlimited, shopType.toID(), this.getPrice(), x, y, z, world,
+                    this.saveExtraToJson());
         } catch (Exception e) {
-            plugin.getLogger().log(Level.WARNING, "Could not update a shop in the database! Changes will revert after a reboot!", e);
+            plugin.getLogger().log(Level.WARNING,
+                "Could not update a shop in the database! Changes will revert after a reboot!", e);
         }
         this.dirty = false;
     }
@@ -747,9 +796,10 @@ public class ContainerShop implements Shop {
         }
         if (displayItem != null) {
             displayItem.remove();
-            initDisplayItem();
-            displayItem.spawn();
         }
+        initDisplayItem();
+        displayItem.spawn();
+
         setSignText();
     }
 
@@ -771,11 +821,12 @@ public class ContainerShop implements Shop {
         plugin.getShopManager().loadShop(this.getLocation().getWorld().getName(), this);
         plugin.getShopManager().getLoadedShops().add(this);
         plugin.getShopContainerWatcher().scheduleCheck(this);
+
         // check price restriction
-
-
-        if (plugin.getShopManager().getPriceLimiter().check(item, price) != PriceLimiter.Status.PASS) {
-            Entry<Double, Double> priceRestriction = Util.getPriceRestriction(this.getMaterial()); //TODO Adapt priceLimiter, also improve priceLimiter return a container
+        if (plugin.getShopManager().getPriceLimiter().check(item, price)
+            != PriceLimiter.Status.PASS) {
+            Entry<Double, Double> priceRestriction = Util.getPriceRestriction(
+                this.getMaterial()); //TODO Adapt priceLimiter, also improve priceLimiter return a container
             if (priceRestriction != null) {
                 if (price < priceRestriction.getKey()) {
                     setDirty();
@@ -788,7 +839,6 @@ public class ContainerShop implements Shop {
                 }
             }
         }
-        this.checkDisplay();
     }
 
     /**
@@ -809,7 +859,8 @@ public class ContainerShop implements Shop {
         setDirty();
         this.moderator = shopModerator;
         update();
-        Util.mainThreadRun(() -> plugin.getServer().getPluginManager().callEvent(new ShopModeratorChangedEvent(this, this.moderator)));
+        Util.mainThreadRun(() -> plugin.getServer().getPluginManager()
+            .callEvent(new ShopModeratorChangedEvent(this, this.moderator)));
     }
 
     /**
@@ -835,12 +886,14 @@ public class ContainerShop implements Shop {
         //then change the sign
         Util.mainThreadRun(() -> {
             for (Sign shopSign : signs) {
-                shopSign.setLine(0, MsgUtil.getMessageOfflinePlayer("signs.header", offlinePlayer, ownerName(false)));
+                shopSign.setLine(0, MsgUtil
+                    .getMessageOfflinePlayer("signs.header", offlinePlayer, ownerName(false)));
                 //Don't forgot update it
                 shopSign.update(true);
             }
             //Event
-            plugin.getServer().getPluginManager().callEvent(new ShopModeratorChangedEvent(this, this.moderator));
+            plugin.getServer().getPluginManager()
+                .callEvent(new ShopModeratorChangedEvent(this, this.moderator));
         });
         update();
     }
@@ -917,7 +970,8 @@ public class ContainerShop implements Shop {
         }
         setDirty();
         if (Util.fireCancellableEvent(new ShopTypeChangeEvent(this, this.shopType, newShopType))) {
-            Util.debugLog("Some addon cancelled shop type changes, target shop: " + this.toString());
+            Util.debugLog(
+                "Some addon cancelled shop type changes, target shop: " + this.toString());
             return;
         }
         this.shopType = newShopType;
@@ -956,7 +1010,8 @@ public class ContainerShop implements Shop {
             }
             Sign sign = (Sign) state;
             String[] lines = sign.getLines();
-            if (lines[0].isEmpty() && lines[1].isEmpty() && lines[2].isEmpty() && lines[3].isEmpty()) {
+            if (lines[0].isEmpty() && lines[1].isEmpty() && lines[2].isEmpty() && lines[3]
+                .isEmpty()) {
                 signs.add(sign); //NEW SIGN
                 continue;
             }
@@ -965,10 +1020,11 @@ public class ContainerShop implements Shop {
             if (lines[1].startsWith(shopSignPattern)) {
                 signs.add(sign);
             } else {
-                String adminShopHeader = MsgUtil.getMessageOfflinePlayer("signs.header", null, MsgUtil.getMessageOfflinePlayer(
+                String adminShopHeader = MsgUtil
+                    .getMessageOfflinePlayer("signs.header", null, MsgUtil.getMessageOfflinePlayer(
                         "admin-shop", plugin.getServer().getOfflinePlayer(this.getOwner())));
                 String signHeaderUsername =
-                        MsgUtil.getMessageOfflinePlayer("signs.header", null, this.ownerName(true));
+                    MsgUtil.getMessageOfflinePlayer("signs.header", null, this.ownerName(true));
                 if (header.contains(adminShopHeader) || header.contains(signHeaderUsername)) {
                     signs.add(sign);
                     //TEXT SIGN
@@ -986,7 +1042,8 @@ public class ContainerShop implements Shop {
     @NotNull
     @Override
     public List<UUID> getStaffs() {
-        return new ArrayList<>(this.moderator.getStaffs()); //Clone only, so make sure external calling will use addStaff
+        return new ArrayList<>(this.moderator
+            .getStaffs()); //Clone only, so make sure external calling will use addStaff
     }
 
     @Override
@@ -1070,16 +1127,17 @@ public class ContainerShop implements Shop {
     @Override
     public String toString() {
         StringBuilder sb =
-                new StringBuilder(
-                        "Shop "
-                                + (location.getWorld() == null ? "unloaded world" : location.getWorld().getName())
-                                + "("
-                                + location.getBlockX()
-                                + ", "
-                                + location.getBlockY()
-                                + ", "
-                                + location.getBlockZ()
-                                + ")");
+            new StringBuilder(
+                "Shop "
+                    + (location.getWorld() == null ? "unloaded world"
+                    : location.getWorld().getName())
+                    + "("
+                    + location.getBlockX()
+                    + ", "
+                    + location.getBlockY()
+                    + ", "
+                    + location.getBlockZ()
+                    + ")");
         sb.append(" Owner: ").append(this.ownerName(false)).append(" - ").append(getOwner());
         if (isUnlimited()) {
             sb.append(" Unlimited: true");
@@ -1112,19 +1170,19 @@ public class ContainerShop implements Shop {
     /**
      * @return The chest this shop is based on.
      */
-
     public @Nullable Inventory getInventory() {
         Util.ensureThread(false);
         BlockState state = PaperLib.getBlockState(location.getBlock(), false).getState();
         try {
             if (state.getType() == Material.ENDER_CHEST
-                    && plugin.getOpenInvPlugin() != null) { //FIXME: Need better impl
+                && plugin.getOpenInvPlugin() != null) { //FIXME: Need better impl
                 OpenInv openInv = ((OpenInv) plugin.getOpenInvPlugin());
                 return openInv.getSpecialEnderChest(
-                        Objects.requireNonNull(
-                                openInv.loadPlayer(plugin.getServer().getOfflinePlayer(this.moderator.getOwner()))),
-                        plugin.getServer().getOfflinePlayer((this.moderator.getOwner())).isOnline())
-                        .getBukkitInventory();
+                    Objects.requireNonNull(
+                        openInv.loadPlayer(
+                            plugin.getServer().getOfflinePlayer(this.moderator.getOwner()))),
+                    plugin.getServer().getOfflinePlayer((this.moderator.getOwner())).isOnline())
+                    .getBukkitInventory();
             }
         } catch (Exception e) {
             Util.debugLog(e.getMessage());
@@ -1140,7 +1198,8 @@ public class ContainerShop implements Shop {
                 if (createBackup) {
                     plugin.log("Deleting shop " + this + " request by invalid inventory.");
                     this.delete();
-                    Util.debugLog("Inventory doesn't exist anymore: " + this + " shop was removed.");
+                    Util.debugLog(
+                        "Inventory doesn't exist anymore: " + this + " shop was removed.");
                 }
             } else {
                 plugin.log("Deleting shop " + this + " request by invalid inventory.");
@@ -1176,14 +1235,61 @@ public class ContainerShop implements Shop {
     }
 
     /**
+     * Returns true if this shop is a double chest and the other shop has the same item.
+     * This was needed since DisplayItems should be shared even if they're both selling or buying.
+     *
+     * @return true if this shop is a double chest and the other shop has the same item.
+     */
+    @Override
+    public boolean isRealDouble() {
+        Util.ensureThread(false);
+        ContainerShop nextTo = this.getAttachedShop();
+        if (nextTo == null) {
+            return false;
+        }
+        return nextTo.matches(this.getItem());
+    }
+
+    /**
+     * This function calculates which block of a double chest is the left block,
+     * relative to the direction the chest is facing. Left shops don't spawn items since
+     * they merge items with the right shop.
+     *
+     * @return Whether or not this shop is the left half of a double chest shop.
+     */
+    @Override
+    public boolean isLeftShop() {
+        if (getAttachedShop() == null) {
+            return false;
+        }
+
+        float yaw = getLocation().getYaw();
+        if (yaw == 0) {
+            // left block has a smaller x value
+            return getLocation().getX() < getAttachedShop().getLocation().getX();
+        } else if (yaw == 180) {
+            // left block has greater x value
+            return getLocation().getX() > getAttachedShop().getLocation().getX();
+        } else if (yaw > 45 && yaw < 135) {
+            // left block has a smaller z value
+            return getLocation().getZ() < getAttachedShop().getLocation().getZ();
+        } else if (yaw > 225 && yaw < 315) {
+            // left block has a greater z value
+            return getLocation().getZ() > getAttachedShop().getLocation().getZ();
+        }
+        return false;
+    }
+
+    /**
      * Returns the shop that shares it's inventory with this one.
      *
-     * @return the shop that shares it's inventory with this one. Will return null if this shop is not
-     * attached to another.
+     * @return the shop that shares it's inventory with this one. Will return null if this shop is
+     * not attached to another.
      */
     public @Nullable ContainerShop getAttachedShop() {
         Util.ensureThread(false);
-        Block c = Util.getSecondHalf(PaperLib.getBlockState(this.getLocation().getBlock(), false).getState());
+        Block c = Util
+            .getSecondHalf(PaperLib.getBlockState(this.getLocation().getBlock(), false).getState());
         if (c == null) {
             return null;
         }
@@ -1198,7 +1304,8 @@ public class ContainerShop implements Shop {
      */
     public boolean isDoubleChestShop() {
         Util.ensureThread(false);
-        return Util.isDoubleChest(PaperLib.getBlockState(this.getLocation().getBlock(), false).getState());
+        return Util
+            .isDoubleChest(PaperLib.getBlockState(this.getLocation().getBlock(), false).getState());
     }
 
     /**
@@ -1213,7 +1320,8 @@ public class ContainerShop implements Shop {
             return;
         }
         if (!Util.canBeShop(this.getLocation().getBlock())) {
-            Util.debugLog("Shop at " + this.getLocation() + "@" + this.getLocation().getBlock() + " container was missing, unload from memory...");
+            Util.debugLog("Shop at " + this.getLocation() + "@" + this.getLocation().getBlock()
+                + " container was missing, unload from memory...");
             this.onUnload();
             this.delete(true);
 //            if (!createBackup) {
@@ -1234,9 +1342,9 @@ public class ContainerShop implements Shop {
     }
 
     /**
-     * Gets the plugin's k-v map to storage the data.
-     * It is spilt by plugin name, different name have different map, the data won't conflict.
-     * But if you plugin name is too common, add a prefix will be a good idea.
+     * Gets the plugin's k-v map to storage the data. It is spilt by plugin name, different name
+     * have different map, the data won't conflict. But if you plugin name is too common, add a
+     * prefix will be a good idea.
      *
      * @param plugin Plugin instance
      * @return The data table
@@ -1287,8 +1395,8 @@ public class ContainerShop implements Shop {
     }
 
     /**
-     * WARNING: This UUID will changed after plugin reload, shop reload or server restart
-     * DO NOT USE IT TO STORE DATA!
+     * WARNING: This UUID will changed after plugin reload, shop reload or server restart DO NOT USE
+     * IT TO STORE DATA!
      *
      * @return Random UUID
      */

--- a/src/main/java/org/maxgamer/quickshop/shop/ContainerShop.java
+++ b/src/main/java/org/maxgamer/quickshop/shop/ContainerShop.java
@@ -336,6 +336,10 @@ public class ContainerShop implements Shop {
             return;
         }
 
+        if (isLeftShop()) {
+            return;
+        }
+
         if (this.displayItem == null) {
             Util.debugLog("Warning: DisplayItem is null, this shouldn't happened...");
             StackTraceElement traceElements = Thread.currentThread().getStackTrace()[2];

--- a/src/main/java/org/maxgamer/quickshop/shop/DisplayItem.java
+++ b/src/main/java/org/maxgamer/quickshop/shop/DisplayItem.java
@@ -136,6 +136,7 @@ public abstract class DisplayItem {
         }
         String defaultMark = ShopProtectionFlag.getDefaultMark();
         String shopLocation = shop.getLocation().toString();
+        String attachedShopLocation = (shop.getAttachedShop() == null ? "null" : shop.getAttachedShop().getLocation().toString());
         //noinspection ConstantConditions
         for (String lore : iMeta.getLore()) {
             try {
@@ -149,7 +150,8 @@ public abstract class DisplayItem {
                 if (!ShopProtectionFlag.getMark().equals(defaultMark)) {
                     continue;
                 }
-                if (shopProtectionFlag.getShopLocation().equals(shopLocation)) {
+                if (shopProtectionFlag.getShopLocation().equals(shopLocation)
+                || shopProtectionFlag.getShopLocation().equals(attachedShopLocation)) {
                     return true;
                 }
             } catch (JsonSyntaxException e) {

--- a/src/main/java/org/maxgamer/quickshop/shop/DisplayItem.java
+++ b/src/main/java/org/maxgamer/quickshop/shop/DisplayItem.java
@@ -299,11 +299,27 @@ public abstract class DisplayItem {
     public abstract Entity getDisplay();
 
     /**
-     * Get display should at location. Not display current location.
+     * Gets the display location for an item. If it is a double shop and it is not the left shop,
+     * it will average the locations of the two chests comprising it to be perfectly in the middle.
+     * If it is the left shop, it will return null since the left shop does not spawn an item.
+     * Otherwise, it will give you the middle of the single chest.
      *
-     * @return Should at
+     * @return The Location that the item *should* be displaying at.
      */
-    public abstract Location getDisplayLocation();
+    public @Nullable Location getDisplayLocation() {
+        Util.ensureThread(false);
+        if (shop.isRealDouble()) {
+            if (shop.isLeftShop()) {
+                Util.debugLog("Shop is left shop, so location is null.");
+                return null;
+            }
+            double avgX = (shop.getLocation().getX() + shop.getAttachedShop().getLocation().getX()) / 2;
+            double avgZ = (shop.getLocation().getZ() + shop.getAttachedShop().getLocation().getZ()) / 2;
+            Location newloc = new Location(shop.getLocation().getWorld(), avgX, shop.getLocation().getY(), avgZ, shop.getLocation().getYaw(), shop.getLocation().getPitch());
+            return newloc.add(0.5, 1.2, 0.5);
+        }
+        return this.shop.getLocation().clone().add(0.5, 1.2, 0.5);
+    }
 
     /**
      * Check the display is or not already spawned

--- a/src/main/java/org/maxgamer/quickshop/shop/DisplayItem.java
+++ b/src/main/java/org/maxgamer/quickshop/shop/DisplayItem.java
@@ -136,7 +136,7 @@ public abstract class DisplayItem {
         }
         String defaultMark = ShopProtectionFlag.getDefaultMark();
         String shopLocation = shop.getLocation().toString();
-        String attachedShopLocation = null;
+        String attachedShopLocation = "null";
         if (shop.isRealDouble()) {
             attachedShopLocation = shop.getAttachedShop().getLocation().toString();
         }

--- a/src/main/java/org/maxgamer/quickshop/shop/DisplayItem.java
+++ b/src/main/java/org/maxgamer/quickshop/shop/DisplayItem.java
@@ -136,7 +136,7 @@ public abstract class DisplayItem {
         }
         String defaultMark = ShopProtectionFlag.getDefaultMark();
         String shopLocation = shop.getLocation().toString();
-        String attachedShopLocation = (shop.getAttachedShop() == null ? "null" : shop.getAttachedShop().getLocation().toString());
+        String attachedShopLocation = (!shop.isRealDouble()) ? "null" : (shop.getAttachedShop() == null ? "null" : shop.getAttachedShop().getLocation().toString());
         //noinspection ConstantConditions
         for (String lore : iMeta.getLore()) {
             try {

--- a/src/main/java/org/maxgamer/quickshop/shop/DisplayItem.java
+++ b/src/main/java/org/maxgamer/quickshop/shop/DisplayItem.java
@@ -136,7 +136,10 @@ public abstract class DisplayItem {
         }
         String defaultMark = ShopProtectionFlag.getDefaultMark();
         String shopLocation = shop.getLocation().toString();
-        String attachedShopLocation = (!shop.isRealDouble()) ? "null" : (shop.getAttachedShop() == null ? "null" : shop.getAttachedShop().getLocation().toString());
+        String attachedShopLocation = null;
+        if (shop.isRealDouble()) {
+            attachedShopLocation = shop.getAttachedShop().getLocation().toString();
+        }
         //noinspection ConstantConditions
         for (String lore : iMeta.getLore()) {
             try {

--- a/src/main/java/org/maxgamer/quickshop/shop/RealDisplayItem.java
+++ b/src/main/java/org/maxgamer/quickshop/shop/RealDisplayItem.java
@@ -273,33 +273,6 @@ public class RealDisplayItem extends DisplayItem {
     }
 
     /**
-     * Gets the display location for an item. If it is a double shop and it is not the left shop,
-     * it will average the locations of the two chests comprising it to be perfectly in the middle.
-     * If it is the left shop, it will return null since the left shop does not spawn an item.
-     * Otherwise, it will give you the middle of the single chest.
-     *
-     * @return Location to spawn the DisplayItem.
-     */
-    @Override
-    public @Nullable Location getDisplayLocation() {
-        Util.ensureThread(false);
-        if (shop.isRealDouble()) {
-            if (shop.isLeftShop()) {
-                return null;
-            }
-            double avgX =
-                (shop.getLocation().getX() + shop.getAttachedShop().getLocation().getX()) / 2;
-            double avgZ =
-                (shop.getLocation().getZ() + shop.getAttachedShop().getLocation().getZ()) / 2;
-            Location newloc = new Location(shop.getLocation().getWorld(), avgX,
-                shop.getLocation().getY(), avgZ,
-                shop.getLocation().getYaw(), shop.getLocation().getPitch());
-            return newloc.add(0.5, 1.2, 0.5);
-        }
-        return this.shop.getLocation().clone().add(0.5, 1.2, 0.5);
-    }
-
-    /**
      * Gets either the item spawn location of this item's chest, or the attached chest.
      * Used for checking for duplicates.
      *

--- a/src/main/java/org/maxgamer/quickshop/shop/RealDisplayItem.java
+++ b/src/main/java/org/maxgamer/quickshop/shop/RealDisplayItem.java
@@ -61,7 +61,7 @@ public class RealDisplayItem extends DisplayItem {
         if (this.item == null) {
             return false;
         }
-        if (shop.isRealDouble() && shop.isLeftShop()) {
+        if (shop.isLeftShop()) {
             return false;
         }
         // return !this.item.getLocation().equals(getDisplayLocation());
@@ -111,7 +111,7 @@ public class RealDisplayItem extends DisplayItem {
             }
             Item eItem = (Item) entity;
             if (eItem.getUniqueId().equals(Objects.requireNonNull(this.item).getUniqueId())) {
-                if (shop.isRealDouble() && shop.isLeftShop()) {
+                if (shop.isLeftShop()) {
                     return;
                 }
                 Util.debugLog(
@@ -150,6 +150,9 @@ public class RealDisplayItem extends DisplayItem {
     @Override
     public boolean removeDupe() {
         Util.ensureThread(false);
+        if (shop.isLeftShop()) {
+            return false;
+        }
         if (this.item == null) {
             Util.debugLog("Warning: Trying to removeDupe for a null display shop.");
             return false;
@@ -220,7 +223,7 @@ public class RealDisplayItem extends DisplayItem {
     @Override
     public void spawn() {
         Util.ensureThread(false);
-        if (shop.isRealDouble() && shop.isLeftShop()) {
+        if (shop.isLeftShop()) {
             return;
         }
         if (shop.isDeleted() || !shop.isLoaded()) {

--- a/src/main/java/org/maxgamer/quickshop/shop/RealDisplayItem.java
+++ b/src/main/java/org/maxgamer/quickshop/shop/RealDisplayItem.java
@@ -134,7 +134,7 @@ public class RealDisplayItem extends DisplayItem {
     @Override
     public void remove() {
         Util.ensureThread(false);
-        if (this.item == null || shop.isLeftShop()) {
+        if (this.item == null) {
             Util.debugLog(
                 "Ignore the Item removing because the Item is already gone or it's a left shop.");
             return;

--- a/src/main/java/org/maxgamer/quickshop/shop/RealDisplayItem.java
+++ b/src/main/java/org/maxgamer/quickshop/shop/RealDisplayItem.java
@@ -324,9 +324,11 @@ public class RealDisplayItem extends DisplayItem {
             return false;
         }
         // If it's a left shop, check the attached shop's item instead.
-        if (shop.isLeftShop() && shop.getAttachedShop().getDisplayItem() != null
-            && shop.getAttachedShop().getDisplayItem().isSpawned()) {
-            return true;
+        if (shop.isLeftShop()) {
+            if (shop.getAttachedShop().getDisplayItem() == null) {
+                return false;
+            }
+            return shop.getAttachedShop().getDisplayItem().isSpawned();
         }
         return this.item.isValid();
     }

--- a/src/main/java/org/maxgamer/quickshop/shop/Shop.java
+++ b/src/main/java/org/maxgamer/quickshop/shop/Shop.java
@@ -470,15 +470,12 @@ public interface Shop {
      */
     void openPreview(@NotNull Player player);
 
-    /**
-     * Gets the shop attached to this one.
-     *
-     * @return The shop attached to this shop.
-     */
-    ContainerShop getAttachedShop();
-
     boolean isLeftShop();
 
     boolean isRealDouble();
+
+    void updateAttachedShop();
+
+    ContainerShop getAttachedShop();
 
 }

--- a/src/main/java/org/maxgamer/quickshop/shop/Shop.java
+++ b/src/main/java/org/maxgamer/quickshop/shop/Shop.java
@@ -470,12 +470,28 @@ public interface Shop {
      */
     void openPreview(@NotNull Player player);
 
+    /**
+     * Returns the current cached isLeftShop state of the Shop
+     * @return if the shop is a left shop
+     */
     boolean isLeftShop();
 
+    /**
+     * Returns the current cached isRealDouble state of the Shop
+     * @return if the shop is a RealDouble
+     */
     boolean isRealDouble();
 
+    /**
+     * Updates the attachedShop variable to reflect the currently attached shop, if any.
+     * Also updates the left shop status.
+     */
     void updateAttachedShop();
 
+    /**
+     * Returns the attached shop object if any, otherwise null.
+     * @return Shop or null
+     */
     ContainerShop getAttachedShop();
 
 }

--- a/src/main/java/org/maxgamer/quickshop/shop/Shop.java
+++ b/src/main/java/org/maxgamer/quickshop/shop/Shop.java
@@ -470,4 +470,15 @@ public interface Shop {
      */
     void openPreview(@NotNull Player player);
 
+    /**
+     * Gets the shop attached to this one.
+     *
+     * @return The shop attached to this shop.
+     */
+    ContainerShop getAttachedShop();
+
+    boolean isLeftShop();
+
+    boolean isRealDouble();
+
 }

--- a/src/main/java/org/maxgamer/quickshop/shop/ShopManager.java
+++ b/src/main/java/org/maxgamer/quickshop/shop/ShopManager.java
@@ -69,31 +69,32 @@ public class ShopManager {
     private final boolean useOldCanBuildAlgorithm;
     private final boolean autoSign;
     private final Cache<UUID, Shop> shopRuntimeUUIDCaching =
-            CacheBuilder.newBuilder()
-                    .expireAfterAccess(120, TimeUnit.SECONDS)
-                    .maximumSize(50)
-                    .weakValues()
-                    .initialCapacity(5)
-                    .build();
+        CacheBuilder.newBuilder()
+            .expireAfterAccess(120, TimeUnit.SECONDS)
+            .maximumSize(50)
+            .weakValues()
+            .initialCapacity(5)
+            .build();
 
     public ShopManager(@NotNull QuickShop plugin) {
         Util.ensureThread(false);
         this.plugin = plugin;
         this.useFastShopSearchAlgorithm =
-                plugin.getConfig().getBoolean("shop.use-fast-shop-search-algorithm", false);
+            plugin.getConfig().getBoolean("shop.use-fast-shop-search-algorithm", false);
         Util.debugLog("Loading caching tax account...");
         String taxAccount = plugin.getConfig().getString("tax-account", "tax");
         if (!(taxAccount == null || taxAccount.isEmpty())) {
-            this.cacheTaxAccount = new Trader(taxAccount, plugin.getServer().getOfflinePlayer(taxAccount));
+            this.cacheTaxAccount = new Trader(taxAccount,
+                plugin.getServer().getOfflinePlayer(taxAccount));
         } else {
             // disable tax account
             cacheTaxAccount = null;
         }
         this.priceLimiter =
-                new PriceLimiter(
-                        plugin.getConfig().getDouble("shop.minimum-price"),
-                        plugin.getConfig().getInt("shop.maximum-price"),
-                        plugin.getConfig().getBoolean("shop.allow-free-shop"));
+            new PriceLimiter(
+                plugin.getConfig().getDouble("shop.minimum-price"),
+                plugin.getConfig().getInt("shop.maximum-price"),
+                plugin.getConfig().getBoolean("shop.allow-free-shop"));
         this.useOldCanBuildAlgorithm = plugin.getConfig().getBoolean("limits.old-algorithm");
         this.autoSign = plugin.getConfig().getBoolean("shop.auto-sign");
     }
@@ -122,9 +123,10 @@ public class ShopManager {
             int max = plugin.getShopLimit(p);
             if (owned + 1 > max) {
                 MsgUtil.sendMessage(
-                        p,
-                        MsgUtil.getMessage(
-                                "reached-maximum-can-create", p, String.valueOf(owned), String.valueOf(max)));
+                    p,
+                    MsgUtil.getMessage(
+                        "reached-maximum-can-create", p, String.valueOf(owned),
+                        String.valueOf(max)));
                 return false;
             }
         }
@@ -152,8 +154,8 @@ public class ShopManager {
     }
 
     /**
-     * Removes all shops from memory and the world. Does not delete them from the database. Call this
-     * on plugin disable ONLY.
+     * Removes all shops from memory and the world. Does not delete them from the database. Call
+     * this on plugin disable ONLY.
      */
     public void clear() {
         Util.ensureThread(false);
@@ -179,7 +181,8 @@ public class ShopManager {
     /**
      * Returns a map of Shops
      *
-     * @param c The chunk to search. Referencing doesn't matter, only coordinates and world are used.
+     * @param c The chunk to search. Referencing doesn't matter, only coordinates and world are
+     *          used.
      * @return Shops
      */
     public @Nullable Map<Location, Shop> getShops(@NotNull Chunk c) {
@@ -222,11 +225,11 @@ public class ShopManager {
         }
         if (info.getSignBlock() != null && autoSign) {
             if (Util.isAir(info.getSignBlock().getType())
-                    || info.getSignBlock().getType() == Material.WATER) {
+                || info.getSignBlock().getType() == Material.WATER) {
                 info.getSignBlock().setType(Util.getSignMaterial());
                 BlockState bs = info.getSignBlock().getState();
                 if (info.getSignBlock().getType() == Material.WATER
-                        && (bs.getBlockData() instanceof Waterlogged)) {
+                    && (bs.getBlockData() instanceof Waterlogged)) {
                     Waterlogged waterable = (Waterlogged) bs.getBlockData();
                     waterable.setWaterlogged(true); // Looks like sign directly put in water
                 }
@@ -238,12 +241,10 @@ public class ShopManager {
                         bs.setBlockData(signBlockDataType);
                     }
                 } else {
-                    plugin
-                            .getLogger()
-                            .warning(
-                                    "Sign material "
-                                            + bs.getType().name()
-                                            + " not a WallSign, make sure you using correct sign material.");
+                    plugin.getLogger().warning(
+                        "Sign material "
+                            + bs.getType().name()
+                            + " not a WallSign, make sure you using correct sign material.");
                 }
                 bs.update(true);
             } else {
@@ -261,31 +262,21 @@ public class ShopManager {
         // sync add to prevent compete issue
         addShop(shop.getLocation().getWorld().getName(), shop);
         // save to database
-        plugin
-                .getDatabaseHelper()
-                .createShop(
-                        shop,
-                        null,
-                        e ->
-                                plugin.getServer().getScheduler()
-                                        .runTask(
-                                                plugin,
-                                                () -> {
-                                                    // also remove from memory when failed
-                                                    shop.delete(true);
-                                                    plugin
-                                                            .getLogger()
-                                                            .warning("Shop create failed, trying to auto fix the database...");
-                                                    boolean backupSuccess = Util.backupDatabase();
-                                                    if (backupSuccess) {
-                                                        plugin.getDatabaseHelper().removeShop(shop);
-                                                    } else {
-                                                        plugin
-                                                                .getLogger()
-                                                                .warning(
-                                                                        "Failed to backup the database, all changes will revert after a reboot.");
-                                                    }
-                                                }));
+        plugin.getDatabaseHelper().createShop(shop, null, e ->
+            plugin.getServer().getScheduler().runTask(
+                plugin, () -> {
+                    // also remove from memory when failed
+                    shop.delete(true);
+                    plugin.getLogger()
+                        .warning("Shop create failed, trying to auto fix the database...");
+                    boolean backupSuccess = Util.backupDatabase();
+                    if (backupSuccess) {
+                        plugin.getDatabaseHelper().removeShop(shop);
+                    } else {
+                        plugin.getLogger().warning(
+                            "Failed to backup the database, all changes will revert after a reboot.");
+                    }
+                }));
     }
 
     /**
@@ -376,7 +367,8 @@ public class ShopManager {
             }
             // Ooops, not founded that shop in this chunk.
         }
-        @Nullable Block secondHalfShop = Util.getSecondHalf(PaperLib.getBlockState(loc.getBlock(), false).getState());
+        @Nullable Block secondHalfShop = Util
+            .getSecondHalf(PaperLib.getBlockState(loc.getBlock(), false).getState());
         if (secondHalfShop != null) {
             inChunk = getShops(secondHalfShop.getChunk());
             if (inChunk != null) {
@@ -426,7 +418,7 @@ public class ShopManager {
 
     @Nullable
     public Shop getShopFromRuntimeRandomUniqueId(
-            @NotNull UUID runtimeRandomUniqueId, boolean includeInvalid) {
+        @NotNull UUID runtimeRandomUniqueId, boolean includeInvalid) {
         Shop shop = shopRuntimeUUIDCaching.getIfPresent(runtimeRandomUniqueId);
         if (shop == null) {
             for (Shop shopWithoutCache : this.getLoadedShops()) {
@@ -456,25 +448,25 @@ public class ShopManager {
         final String message = ChatColor.stripColor(msg);
         // Use from the main thread, because Bukkit hates life
         plugin.getServer().getScheduler()
-                .runTask(plugin, () -> {
-                    Map<UUID, Info> actions = getActions();
-                    // They wanted to do something.
-                    Info info = actions.remove(p.getUniqueId());
-                    if (info == null) {
-                        return; // multithreaded means this can happen
-                    }
-                    if (info.getLocation().getWorld() != p.getLocation().getWorld()
-                            || info.getLocation().distanceSquared(p.getLocation()) > 25) {
-                        MsgUtil.sendMessage(p, MsgUtil.getMessage("not-looking-at-shop", p));
-                        return;
-                    }
-                    if (info.getAction() == ShopAction.CREATE) {
-                        actionCreate(p, info, message, bypassProtectionChecks);
-                    }
-                    if (info.getAction() == ShopAction.BUY) {
-                        actionTrade(p, info, message);
-                    }
-                });
+            .runTask(plugin, () -> {
+                Map<UUID, Info> actions = getActions();
+                // They wanted to do something.
+                Info info = actions.remove(p.getUniqueId());
+                if (info == null) {
+                    return; // multithreaded means this can happen
+                }
+                if (info.getLocation().getWorld() != p.getLocation().getWorld()
+                    || info.getLocation().distanceSquared(p.getLocation()) > 25) {
+                    MsgUtil.sendMessage(p, MsgUtil.getMessage("not-looking-at-shop", p));
+                    return;
+                }
+                if (info.getAction() == ShopAction.CREATE) {
+                    actionCreate(p, info, message, bypassProtectionChecks);
+                }
+                if (info.getAction() == ShopAction.BUY) {
+                    actionTrade(p, info, message);
+                }
+            });
     }
 
     /**
@@ -489,15 +481,16 @@ public class ShopManager {
     }
 
     /**
-     * Adds a shop to the world. Does NOT require the chunk or world to be loaded Call shop.onLoad by
-     * yourself
+     * Adds a shop to the world. Does NOT require the chunk or world to be loaded Call shop.onLoad
+     * by yourself
      *
      * @param world The name of the world
      * @param shop  The shop to add
      */
     public void addShop(@NotNull String world, @NotNull Shop shop) {
         Map<ShopChunk, Map<Location, Shop>> inWorld =
-                this.getShops().computeIfAbsent(world, k -> new MapMaker().initialCapacity(3).makeMap());
+            this.getShops()
+                .computeIfAbsent(world, k -> new MapMaker().initialCapacity(3).makeMap());
         // There's no world storage yet. We need to create that map.
         // Put it in the data universe
         // Calculate the chunks coordinates. These are 1,2,3 for each chunk, NOT
@@ -507,7 +500,7 @@ public class ShopManager {
         // Get the chunk set from the world info
         ShopChunk shopChunk = new ShopChunk(world, x, z);
         Map<Location, Shop> inChunk =
-                inWorld.computeIfAbsent(shopChunk, k -> new MapMaker().initialCapacity(1).makeMap());
+            inWorld.computeIfAbsent(shopChunk, k -> new MapMaker().initialCapacity(1).makeMap());
         // That chunk data hasn't been created yet - Create it!
         // Put it in the world
         // Put the shop in its location in the chunk list.
@@ -517,8 +510,8 @@ public class ShopManager {
     }
 
     /**
-     * Removes a shop from the world. Does NOT remove it from the database. * REQUIRES * the world to
-     * be loaded Call shop.onUnload by your self.
+     * Removes a shop from the world. Does NOT remove it from the database. * REQUIRES * the world
+     * to be loaded Call shop.onUnload by your self.
      *
      * @param shop The shop to remove
      */
@@ -606,12 +599,12 @@ public class ShopManager {
     }
 
     public void actionBuy(
-            @NotNull UUID buyer,
-            @NotNull Inventory buyerInventory,
-            @NotNull Economy eco,
-            @NotNull Info info,
-            @NotNull Shop shop,
-            int amount) {
+        @NotNull UUID buyer,
+        @NotNull Inventory buyerInventory,
+        @NotNull Economy eco,
+        @NotNull Info info,
+        @NotNull Shop shop,
+        int amount) {
         Util.ensureThread(false);
         if (shopIsNotValid(buyer, info, shop)) {
             return;
@@ -622,24 +615,24 @@ public class ShopManager {
         }
         if (space < amount) {
             MsgUtil.sendMessage(
+                buyer,
+                MsgUtil.getMessage(
                     buyer,
-                    MsgUtil.getMessage(
-                            buyer,
-                            "shop-has-no-space",
-                            Integer.toString(space),
-                            Util.getItemStackName(shop.getItem())));
+                    "shop-has-no-space",
+                    Integer.toString(space),
+                    Util.getItemStackName(shop.getItem())));
             return;
         }
         int count = Util.countItems(buyerInventory, shop.getItem());
         // Not enough items
         if (amount > count) {
             MsgUtil.sendMessage(
+                buyer,
+                MsgUtil.getMessage(
                     buyer,
-                    MsgUtil.getMessage(
-                            buyer,
-                            "you-dont-have-that-many-items",
-                            Integer.toString(count),
-                            Util.getItemStackName(shop.getItem())));
+                    "you-dont-have-that-many-items",
+                    Integer.toString(count),
+                    Util.getItemStackName(shop.getItem())));
             return;
         }
         if (amount < 1) {
@@ -660,48 +653,51 @@ public class ShopManager {
         }
         EconomyTransaction transaction;
         if (!shop.isUnlimited()
-                || (plugin.getConfig().getBoolean("shop.pay-unlimited-shop-owners")
-                && shop.isUnlimited())) {
+            || (plugin.getConfig().getBoolean("shop.pay-unlimited-shop-owners")
+            && shop.isUnlimited())) {
             transaction =
-                    EconomyTransaction.builder()
-                            .core(eco)
-                            .amount(total)
-                            .from(shop.getOwner())
-                            .to(buyer)
-                            .taxModifier(taxModifier)
-                            .taxAccount(cacheTaxAccount)
-                            .currency(shop.getCurrency())
-                            .build();
+                EconomyTransaction.builder()
+                    .core(eco)
+                    .amount(total)
+                    .from(shop.getOwner())
+                    .to(buyer)
+                    .taxModifier(taxModifier)
+                    .taxAccount(cacheTaxAccount)
+                    .currency(shop.getCurrency())
+                    .build();
         } else {
             transaction =
-                    EconomyTransaction.builder()
-                            .core(eco)
-                            .amount(total)
-                            .from(null)
-                            .to(buyer)
-                            .taxModifier(taxModifier)
-                            .taxAccount(cacheTaxAccount)
-                            .currency(shop.getCurrency())
-                            .build();
+                EconomyTransaction.builder()
+                    .core(eco)
+                    .amount(total)
+                    .from(null)
+                    .to(buyer)
+                    .taxModifier(taxModifier)
+                    .taxAccount(cacheTaxAccount)
+                    .currency(shop.getCurrency())
+                    .build();
         }
         if (!transaction.failSafeCommit()) {
             if (transaction.getSteps() == EconomyTransaction.TransactionSteps.CHECK) {
                 MsgUtil.sendMessage(
+                    buyer,
+                    MsgUtil.getMessage(
                         buyer,
-                        MsgUtil.getMessage(
-                                buyer,
-                                "the-owner-cant-afford-to-buy-from-you",
-                                Objects.requireNonNull(format(total, shop.getLocation().getWorld(), shop.getCurrency())),
-                                Objects.requireNonNull(
-                                        format(eco.getBalance(shop.getOwner(), shop.getLocation().getWorld(), shop.getCurrency()), shop.getLocation().getWorld(), shop.getCurrency())
-                                )));
+                        "the-owner-cant-afford-to-buy-from-you",
+                        Objects.requireNonNull(
+                            format(total, shop.getLocation().getWorld(), shop.getCurrency())),
+                        Objects.requireNonNull(
+                            format(eco.getBalance(shop.getOwner(), shop.getLocation().getWorld(),
+                                shop.getCurrency()), shop.getLocation().getWorld(),
+                                shop.getCurrency())
+                        )));
             } else {
                 MsgUtil.sendMessage(buyer, MsgUtil.getMessage(buyer, "purchase-failed"));
                 plugin
-                        .getLogger()
-                        .severe("EconomyTransaction Failed, last error:" + transaction.getLastError());
+                    .getLogger()
+                    .severe("EconomyTransaction Failed, last error:" + transaction.getLastError());
                 QuickShop.getInstance()
-                        .log("EconomyTransaction Failed, last error:" + transaction.getLastError());
+                    .log("EconomyTransaction Failed, last error:" + transaction.getLastError());
             }
             return;
         }
@@ -710,22 +706,22 @@ public class ShopManager {
         Player player = plugin.getServer().getPlayer(buyer);
 
         String msg =
-                MsgUtil.getMessage(
-                        buyer,
-                        "player-sold-to-your-store",
-                        player != null ? player.getName() : buyer.toString(),
-                        String.valueOf(amount),
-                        "##########" + Util.serialize(shop.getItem()) + "##########");
+            MsgUtil.getMessage(
+                buyer,
+                "player-sold-to-your-store",
+                player != null ? player.getName() : buyer.toString(),
+                String.valueOf(amount),
+                "##########" + Util.serialize(shop.getItem()) + "##########");
 
         if (space == amount) {
             msg +=
-                    "\n"
-                            + MsgUtil.getMessage(
-                            buyer,
-                            "shop-out-of-space",
-                            Integer.toString(shop.getLocation().getBlockX()),
-                            Integer.toString(shop.getLocation().getBlockY()),
-                            Integer.toString(shop.getLocation().getBlockZ()));
+                "\n"
+                    + MsgUtil.getMessage(
+                    buyer,
+                    "shop-out-of-space",
+                    Integer.toString(shop.getLocation().getBlockX()),
+                    Integer.toString(shop.getLocation().getBlockY()),
+                    Integer.toString(shop.getLocation().getBlockZ()));
         }
         if (plugin.getConfig().getBoolean("shop.sending-stock-message-to-staffs")) {
             for (UUID staff : shop.getModerator().getStaffs()) {
@@ -734,17 +730,19 @@ public class ShopManager {
         }
         MsgUtil.send(shop, shop.getOwner(), msg);
         shop.buy(
-                buyer, buyerInventory, player != null ? player.getLocation() : shop.getLocation(), amount);
+            buyer, buyerInventory, player != null ? player.getLocation() : shop.getLocation(),
+            amount);
         MsgUtil.sendSellSuccess(buyer, shop, amount);
         ShopSuccessPurchaseEvent se =
-                new ShopSuccessPurchaseEvent(shop, buyer, buyerInventory, amount, total, taxModifier);
+            new ShopSuccessPurchaseEvent(shop, buyer, buyerInventory, amount, total, taxModifier);
         plugin.getServer().getPluginManager().callEvent(se);
         shop.setSignText(); // Update the signs count
     }
 
 
     @Deprecated
-    public void actionBuy(@NotNull Player p, @NotNull Economy eco, @NotNull Info info, @NotNull Shop shop, int amount) {
+    public void actionBuy(@NotNull Player p, @NotNull Economy eco, @NotNull Info info,
+        @NotNull Shop shop, int amount) {
         Util.ensureThread(false);
         actionBuy(p.getUniqueId(), p.getInventory(), eco, info, shop, amount);
     }
@@ -761,15 +759,20 @@ public class ShopManager {
         if (player != null) {
             if (QuickShop.getPermissionManager().hasPermission(player, "quickshop.tax")) {
                 tax = 0;
-                Util.debugLog("Disable the Tax for player " + player + " cause they have permission quickshop.tax");
+                Util.debugLog("Disable the Tax for player " + player
+                    + " cause they have permission quickshop.tax");
             }
-            if (shop.isUnlimited() && QuickShop.getPermissionManager().hasPermission(player, "quickshop.tax.bypassunlimited")) {
+            if (shop.isUnlimited() && QuickShop.getPermissionManager()
+                .hasPermission(player, "quickshop.tax.bypassunlimited")) {
                 tax = 0;
-                Util.debugLog("Disable the Tax for player " + player + " cause they have permission quickshop.tax.bypassunlimited and shop is unlimited.");
+                Util.debugLog("Disable the Tax for player " + player
+                    + " cause they have permission quickshop.tax.bypassunlimited and shop is unlimited.");
             }
         }
         if (tax >= 1.0) {
-            plugin.getLogger().warning("Disable tax due to is invalid, it should be in 0.0-1.0 (current value is " + tax + ")");
+            plugin.getLogger().warning(
+                "Disable tax due to is invalid, it should be in 0.0-1.0 (current value is " + tax
+                    + ")");
             tax = 0;
         }
         if (tax < 0) {
@@ -783,14 +786,17 @@ public class ShopManager {
         return taxEvent.getTax();
     }
 
-    public void actionCreate(@NotNull Player p, @NotNull Info info, @NotNull String message, boolean bypassProtectionChecks) {
+    public void actionCreate(@NotNull Player p, @NotNull Info info, @NotNull String message,
+        boolean bypassProtectionChecks) {
         Util.ensureThread(false);
         if (plugin.getEconomy() == null) {
-            MsgUtil.sendMessage(p, "Error: Economy system not loaded, type /qs main command to get details.");
+            MsgUtil.sendMessage(p,
+                "Error: Economy system not loaded, type /qs main command to get details.");
             return;
         }
         if (plugin.isAllowStack() && !p.hasPermission("quickshop.create.stacks")) {
-            Util.debugLog("Player " + p + " no permission to create stacks shop, forcing creating single item shop");
+            Util.debugLog("Player " + p
+                + " no permission to create stacks shop, forcing creating single item shop");
             info.getItem().setAmount(1);
         }
 
@@ -800,8 +806,11 @@ public class ShopManager {
         if (!bypassProtectionChecks) {
             Result result = plugin.getPermissionChecker().canBuild(p, info.getLocation());
             if (!result.isSuccess()) {
-                MsgUtil.sendMessage(p, MsgUtil.getMessage("3rd-plugin-build-check-failed", p, result.getMessage()));
-                Util.debugLog("Failed to create shop because protection check failed, found:" + result.getMessage());
+                MsgUtil.sendMessage(p,
+                    MsgUtil.getMessage("3rd-plugin-build-check-failed", p, result.getMessage()));
+                Util.debugLog(
+                    "Failed to create shop because protection check failed, found:" + result
+                        .getMessage());
                 return;
             }
         }
@@ -810,8 +819,9 @@ public class ShopManager {
             MsgUtil.sendMessage(p, MsgUtil.getMessage("shop-already-owned", p));
             return;
         }
-        if (Util.isDoubleChest(PaperLib.getBlockState(info.getLocation().getBlock(), false).getState())
-                && !QuickShop.getPermissionManager().hasPermission(p, "quickshop.create.double")) {
+        if (Util
+            .isDoubleChest(PaperLib.getBlockState(info.getLocation().getBlock(), false).getState())
+            && !QuickShop.getPermissionManager().hasPermission(p, "quickshop.create.double")) {
             MsgUtil.sendMessage(p, MsgUtil.getMessage("no-double-chests", p));
             return;
         }
@@ -819,7 +829,8 @@ public class ShopManager {
             MsgUtil.sendMessage(p, MsgUtil.getMessage("chest-was-removed", p));
             return;
         }
-        if (info.getLocation().getBlock().getType() == Material.ENDER_CHEST) { // FIXME: Need a better impl
+        if (info.getLocation().getBlock().getType()
+            == Material.ENDER_CHEST) { // FIXME: Need a better impl
             if (!QuickShop.getPermissionManager().hasPermission(p, "quickshop.create.enderchest")) {
                 return;
             }
@@ -834,8 +845,8 @@ public class ShopManager {
             }
             Material signType = info.getSignBlock().getType();
             if (signType != Material.WATER
-                    && !Util.isAir(signType)
-                    && !plugin.getConfig().getBoolean("shop.allow-shop-without-space-for-sign")) {
+                && !Util.isAir(signType)
+                && !plugin.getConfig().getBoolean("shop.allow-shop-without-space-for-sign")) {
                 MsgUtil.sendMessage(p, MsgUtil.getMessage("failed-to-put-sign", p));
                 return;
             }
@@ -860,16 +871,16 @@ public class ShopManager {
                     MsgUtil.sendMessage(p, MsgUtil.getMessage("exceeded-maximum", p, message));
                     return;
                 }
-                String strFormat =
-                        new DecimalFormat("#.#########").format(Math.abs(price)).replace(",", ".");
+                String strFormat = new DecimalFormat("#.#########").format(Math.abs(price))
+                    .replace(",", ".");
                 String[] processedDouble = strFormat.split("\\.");
                 if (processedDouble.length > 1) {
-                    int maximumDigitsLimit = plugin.getConfig().getInt("maximum-digits-in-price", -1);
-                    if (processedDouble[1].length() > maximumDigitsLimit && maximumDigitsLimit != -1) {
-                        MsgUtil.sendMessage(
-                                p,
-                                MsgUtil.getMessage(
-                                        "digits-reach-the-limit", p, String.valueOf(maximumDigitsLimit)));
+                    int maximumDigitsLimit = plugin.getConfig()
+                        .getInt("maximum-digits-in-price", -1);
+                    if (processedDouble[1].length() > maximumDigitsLimit
+                        && maximumDigitsLimit != -1) {
+                        MsgUtil.sendMessage(p, MsgUtil.getMessage("digits-reach-the-limit", p,
+                            String.valueOf(maximumDigitsLimit)));
                         return;
                     }
                 }
@@ -884,36 +895,22 @@ public class ShopManager {
         boolean decFormat = plugin.getConfig().getBoolean("use-decimal-format");
         switch (this.priceLimiter.check(info.getItem(), price)) {
             case REACHED_PRICE_MIN_LIMIT:
-                MsgUtil.sendMessage(
-                        p,
-                        MsgUtil.getMessage(
-                                "price-too-cheap",
-                                p,
-                                (decFormat)
-                                        ? MsgUtil.decimalFormat(this.priceLimiter.getMaxPrice())
-                                        : Double.toString(this.priceLimiter.getMinPrice())));
+                MsgUtil.sendMessage(p, MsgUtil.getMessage("price-too-cheap", p,
+                    (decFormat) ? MsgUtil.decimalFormat(this.priceLimiter.getMaxPrice())
+                        : Double.toString(this.priceLimiter.getMinPrice())));
                 return;
             case REACHED_PRICE_MAX_LIMIT:
-                MsgUtil.sendMessage(
-                        p,
-                        MsgUtil.getMessage(
-                                "price-too-high",
-                                p,
-                                (decFormat)
-                                        ? MsgUtil.decimalFormat(this.priceLimiter.getMaxPrice())
-                                        : Double.toString(this.priceLimiter.getMinPrice())));
+                MsgUtil.sendMessage(p, MsgUtil.getMessage("price-too-high", p,
+                    (decFormat) ? MsgUtil.decimalFormat(this.priceLimiter.getMaxPrice())
+                        : Double.toString(this.priceLimiter.getMinPrice())));
                 return;
             case PRICE_RESTRICTED:
-                Map.Entry<Double, Double> materialLimit =
-                        Util.getPriceRestriction(info.getItem().getType());
-                MsgUtil.sendMessage(
-                        p,
-                        MsgUtil.getMessage(
-                                "restricted-prices",
-                                p,
-                                Util.getItemStackName(info.getItem()),
-                                String.valueOf(materialLimit.getKey()),
-                                String.valueOf(materialLimit.getValue())));
+                Map.Entry<Double, Double> materialLimit = Util
+                    .getPriceRestriction(info.getItem().getType());
+                MsgUtil.sendMessage(p, MsgUtil.getMessage("restricted-prices", p,
+                    Util.getItemStackName(info.getItem()),
+                    String.valueOf(materialLimit.getKey()),
+                    String.valueOf(materialLimit.getValue())));
                 return;
         }
 
@@ -923,22 +920,21 @@ public class ShopManager {
         }
 
         // Create the sample shop
-        ContainerShop shop =
-                new ContainerShop(
-                        plugin,
-                        info.getLocation(),
-                        price,
-                        info.getItem(),
-                        new ShopModerator(p.getUniqueId()),
-                        false,
-                        ShopType.SELLING,
-                        new ConcurrentHashMap<>());
+        ContainerShop shop = new ContainerShop(
+            plugin,
+            info.getLocation(),
+            price,
+            info.getItem(),
+            new ShopModerator(p.getUniqueId()),
+            false,
+            ShopType.SELLING,
+            new ConcurrentHashMap<>());
         if (!bypassProtectionChecks) {
-            Result result =
-                    plugin.getIntegrationHelper().callIntegrationsCanCreate(p, info.getLocation());
+            Result result = plugin.getIntegrationHelper()
+                .callIntegrationsCanCreate(p, info.getLocation());
             if (!result.isSuccess()) {
-                MsgUtil.sendMessage(
-                        p, MsgUtil.getMessage("integrations-check-failed-create", p, result.getMessage()));
+                MsgUtil.sendMessage(p,
+                    MsgUtil.getMessage("integrations-check-failed-create", p, result.getMessage()));
                 Util.debugLog("Cancelled by integrations: " + result);
                 return;
             }
@@ -960,27 +956,27 @@ public class ShopManager {
         }
         if (createCost > 0) {
             EconomyTransaction economyTransaction =
-                    EconomyTransaction.builder()
-                            .taxAccount(cacheTaxAccount)
-                            .taxModifier(0.0)
-                            .core(plugin.getEconomy())
-                            .from(p.getUniqueId())
-                            .to(null)
-                            .amount(createCost)
-                            .currency(plugin.getCurrency())
-                            .build();
+                EconomyTransaction.builder()
+                    .taxAccount(cacheTaxAccount)
+                    .taxModifier(0.0)
+                    .core(plugin.getEconomy())
+                    .from(p.getUniqueId())
+                    .to(null)
+                    .amount(createCost)
+                    .currency(plugin.getCurrency())
+                    .build();
             if (!economyTransaction.failSafeCommit()) {
                 if (economyTransaction.getSteps() == EconomyTransaction.TransactionSteps.CHECK) {
-                    MsgUtil.sendMessage(
-                            p,
-                            MsgUtil.getMessage(
-                                    "you-cant-afford-a-new-shop", p, Objects.requireNonNull(format(createCost, shop.getLocation().getWorld(), shop.getCurrency()))));
+                    MsgUtil.sendMessage(p, MsgUtil.getMessage("you-cant-afford-a-new-shop", p,
+                        Objects.requireNonNull(format(createCost, shop.getLocation().getWorld(),
+                            shop.getCurrency()))));
                 } else {
                     MsgUtil.sendMessage(p, MsgUtil.getMessage("purchase-failed", p));
-                    plugin
-                            .getLogger()
-                            .severe("EconomyTransaction Failed, last error:" + economyTransaction.getLastError());
-                    plugin.log("EconomyTransaction Failed, last error:" + economyTransaction.getLastError());
+                    plugin.getLogger().severe(
+                        "EconomyTransaction Failed, last error:" + economyTransaction
+                            .getLastError());
+                    plugin.log("EconomyTransaction Failed, last error:" + economyTransaction
+                        .getLastError());
                 }
                 return;
             }
@@ -1002,22 +998,31 @@ public class ShopManager {
                 MsgUtil.sendMessage(p, MsgUtil.getMessage("buying-more-than-selling", p));
             }
         }
+
+        // If this is a left shop, update the attached shop to fix the displayitem location.
+        if (shop.isRealDouble() && shop.isLeftShop()) {
+            Shop nextTo = shop.getAttachedShop();
+            Objects.requireNonNull(nextTo).refresh();
+        }
+
+        shop.checkDisplay();
     }
 
     @Deprecated
     public void actionSell(
-            @NotNull Player p, @NotNull Economy eco, @NotNull Info info, @NotNull Shop shop, int amount) {
+        @NotNull Player p, @NotNull Economy eco, @NotNull Info info, @NotNull Shop shop,
+        int amount) {
         Util.ensureThread(false);
         actionSell(p.getUniqueId(), p.getInventory(), eco, info, shop, amount);
     }
 
     public void actionSell(
-            @NotNull UUID seller,
-            @NotNull Inventory sellerInventory,
-            @NotNull Economy eco,
-            @NotNull Info info,
-            @NotNull Shop shop,
-            int amount) {
+        @NotNull UUID seller,
+        @NotNull Inventory sellerInventory,
+        @NotNull Economy eco,
+        @NotNull Info info,
+        @NotNull Shop shop,
+        int amount) {
         Util.ensureThread(false);
         if (shopIsNotValid(seller, info, shop)) {
             return;
@@ -1028,12 +1033,12 @@ public class ShopManager {
         }
         if (stock < amount) {
             MsgUtil.sendMessage(
+                seller,
+                MsgUtil.getMessage(
                     seller,
-                    MsgUtil.getMessage(
-                            seller,
-                            "shop-stock-too-low",
-                            Integer.toString(stock),
-                            Util.getItemStackName(shop.getItem())));
+                    "shop-stock-too-low",
+                    Integer.toString(stock),
+                    Util.getItemStackName(shop.getItem())));
             return;
         }
         if (amount < 1) {
@@ -1044,7 +1049,7 @@ public class ShopManager {
         int pSpace = Util.countSpace(sellerInventory, shop.getItem());
         if (amount > pSpace) {
             MsgUtil.sendMessage(
-                    seller, MsgUtil.getMessage(seller, "not-enough-space", String.valueOf(pSpace)));
+                seller, MsgUtil.getMessage(seller, "not-enough-space", String.valueOf(pSpace)));
             return;
         }
 
@@ -1061,49 +1066,53 @@ public class ShopManager {
         // SELLING Player -> Shop Owner
         EconomyTransaction transaction;
         if (!shop.isUnlimited()
-                || (plugin.getConfig().getBoolean("shop.pay-unlimited-shop-owners")
-                && shop.isUnlimited())) {
+            || (plugin.getConfig().getBoolean("shop.pay-unlimited-shop-owners")
+            && shop.isUnlimited())) {
             transaction =
-                    EconomyTransaction.builder()
-                            .allowLoan(plugin.getConfig().getBoolean("shop.allow-economy-loan", false))
-                            .core(eco)
-                            .from(seller)
-                            .to(shop.getOwner())
-                            .amount(total)
-                            .taxModifier(taxModifier)
-                            .taxAccount(cacheTaxAccount)
-                            .currency(shop.getCurrency())
-                            .build();
+                EconomyTransaction.builder()
+                    .allowLoan(plugin.getConfig().getBoolean("shop.allow-economy-loan", false))
+                    .core(eco)
+                    .from(seller)
+                    .to(shop.getOwner())
+                    .amount(total)
+                    .taxModifier(taxModifier)
+                    .taxAccount(cacheTaxAccount)
+                    .currency(shop.getCurrency())
+                    .build();
         } else {
             transaction =
-                    EconomyTransaction.builder()
-                            .allowLoan(plugin.getConfig().getBoolean("shop.allow-economy-loan", false))
-                            .core(eco)
-                            .from(seller)
-                            .to(null)
-                            .amount(total)
-                            .taxModifier(taxModifier)
-                            .taxAccount(cacheTaxAccount)
-                            .world(shop.getLocation().getWorld())
-                            .currency(shop.getCurrency())
-                            .build();
+                EconomyTransaction.builder()
+                    .allowLoan(plugin.getConfig().getBoolean("shop.allow-economy-loan", false))
+                    .core(eco)
+                    .from(seller)
+                    .to(null)
+                    .amount(total)
+                    .taxModifier(taxModifier)
+                    .taxAccount(cacheTaxAccount)
+                    .world(shop.getLocation().getWorld())
+                    .currency(shop.getCurrency())
+                    .build();
         }
         if (!transaction.failSafeCommit()) {
             if (transaction.getSteps() == EconomyTransaction.TransactionSteps.CHECK) {
                 MsgUtil.sendMessage(
+                    seller,
+                    MsgUtil.getMessage(
                         seller,
-                        MsgUtil.getMessage(
-                                seller,
-                                "you-cant-afford-to-buy",
-                                Objects.requireNonNull(format(total, shop.getLocation().getWorld(), shop.getCurrency())),
-                                Objects.requireNonNull(format(eco.getBalance(seller, shop.getLocation().getWorld(), shop.getCurrency()), shop.getLocation().getWorld(), shop.getCurrency()))));
+                        "you-cant-afford-to-buy",
+                        Objects.requireNonNull(
+                            format(total, shop.getLocation().getWorld(), shop.getCurrency())),
+                        Objects.requireNonNull(format(
+                            eco.getBalance(seller, shop.getLocation().getWorld(),
+                                shop.getCurrency()), shop.getLocation().getWorld(),
+                            shop.getCurrency()))));
             } else {
                 MsgUtil.sendMessage(seller, MsgUtil.getMessage(seller, "purchase-failed"));
                 plugin
-                        .getLogger()
-                        .severe("EconomyTransaction Failed, last error:" + transaction.getLastError());
+                    .getLogger()
+                    .severe("EconomyTransaction Failed, last error:" + transaction.getLastError());
                 QuickShop.getInstance()
-                        .log("EconomyTransaction Failed, last error:" + transaction.getLastError());
+                    .log("EconomyTransaction Failed, last error:" + transaction.getLastError());
             }
             return;
         }
@@ -1113,35 +1122,35 @@ public class ShopManager {
         Player player = plugin.getServer().getPlayer(seller);
         if (plugin.getConfig().getBoolean("show-tax")) {
             msg =
-                    MsgUtil.getMessage(
-                            seller,
-                            "player-bought-from-your-store-tax",
-                            player != null ? player.getName() : seller.toString(),
-                            Integer.toString(amount * shop.getItem().getAmount()),
-                            "##########" + Util.serialize(shop.getItem()) + "##########",
-                            Double.toString(total),
-                            Util.format(CalculateUtil.multiply(taxModifier, total), shop));
+                MsgUtil.getMessage(
+                    seller,
+                    "player-bought-from-your-store-tax",
+                    player != null ? player.getName() : seller.toString(),
+                    Integer.toString(amount * shop.getItem().getAmount()),
+                    "##########" + Util.serialize(shop.getItem()) + "##########",
+                    Double.toString(total),
+                    Util.format(CalculateUtil.multiply(taxModifier, total), shop));
         } else {
             msg =
-                    MsgUtil.getMessage(
-                            seller,
-                            "player-bought-from-your-store",
-                            player != null ? player.getName() : seller.toString(),
-                            Integer.toString(amount * shop.getItem().getAmount()),
-                            "##########" + Util.serialize(shop.getItem()) + "##########",
-                            Double.toString(total));
+                MsgUtil.getMessage(
+                    seller,
+                    "player-bought-from-your-store",
+                    player != null ? player.getName() : seller.toString(),
+                    Integer.toString(amount * shop.getItem().getAmount()),
+                    "##########" + Util.serialize(shop.getItem()) + "##########",
+                    Double.toString(total));
         }
         // Transfers the item from A to B
         if (stock == amount) {
             msg +=
-                    "\n"
-                            + MsgUtil.getMessage(
-                            seller,
-                            "shop-out-of-stock",
-                            Integer.toString(shop.getLocation().getBlockX()),
-                            Integer.toString(shop.getLocation().getBlockY()),
-                            Integer.toString(shop.getLocation().getBlockZ()),
-                            Util.getItemStackName(shop.getItem()));
+                "\n"
+                    + MsgUtil.getMessage(
+                    seller,
+                    "shop-out-of-stock",
+                    Integer.toString(shop.getLocation().getBlockX()),
+                    Integer.toString(shop.getLocation().getBlockY()),
+                    Integer.toString(shop.getLocation().getBlockZ()),
+                    Util.getItemStackName(shop.getItem()));
         }
 
         MsgUtil.send(shop, shop.getOwner(), msg);
@@ -1151,13 +1160,13 @@ public class ShopManager {
             }
         }
         shop.sell(
-                seller,
-                sellerInventory,
-                player != null ? player.getLocation() : shop.getLocation(),
-                amount);
+            seller,
+            sellerInventory,
+            player != null ? player.getLocation() : shop.getLocation(),
+            amount);
         MsgUtil.sendPurchaseSuccess(seller, shop, amount);
         ShopSuccessPurchaseEvent se =
-                new ShopSuccessPurchaseEvent(shop, seller, sellerInventory, amount, total, taxModifier);
+            new ShopSuccessPurchaseEvent(shop, seller, sellerInventory, amount, total, taxModifier);
         plugin.getServer().getPluginManager().callEvent(se);
     }
 
@@ -1168,7 +1177,8 @@ public class ShopManager {
 
     private boolean shopIsNotValid(@Nullable Player p, @NotNull Info info, @NotNull Shop shop) {
         if (plugin.getEconomy() == null) {
-            MsgUtil.sendMessage(p, "Error: Economy system not loaded, type /qs main command to get details.");
+            MsgUtil.sendMessage(p,
+                "Error: Economy system not loaded, type /qs main command to get details.");
             return true;
         }
         if (!Util.canBeShop(info.getLocation().getBlock())) {
@@ -1186,13 +1196,14 @@ public class ShopManager {
         Util.ensureThread(false);
         if (plugin.getEconomy() == null) {
             MsgUtil.sendMessage(
-                    p, "Error: Economy system not loaded, type /qs main command to get details.");
+                p, "Error: Economy system not loaded, type /qs main command to get details.");
             return;
         }
-        Result result = plugin.getIntegrationHelper().callIntegrationsCanTrade(p, info.getLocation());
+        Result result = plugin.getIntegrationHelper()
+            .callIntegrationsCanTrade(p, info.getLocation());
         if (!result.isSuccess()) {
             MsgUtil.sendMessage(
-                    p, MsgUtil.getMessage("integrations-check-failed-trade", p, result.getMessage()));
+                p, MsgUtil.getMessage("integrations-check-failed-trade", p, result.getMessage()));
             Util.debugLog("Cancel by integrations.");
             return;
         }
@@ -1206,7 +1217,7 @@ public class ShopManager {
             return;
         }
         if (p.getGameMode() == GameMode.CREATIVE
-                && plugin.getConfig().getBoolean("shop.disable-creative-mode-trading")) {
+            && plugin.getConfig().getBoolean("shop.disable-creative-mode-trading")) {
             MsgUtil.sendMessage(p, MsgUtil.getMessage("trading-in-creative-mode-is-disabled", p));
             return;
         }
@@ -1220,12 +1231,14 @@ public class ShopManager {
                 amount = Integer.parseInt(message);
             } catch (NumberFormatException e) {
                 if (message.equalsIgnoreCase(
-                        plugin.getConfig().getString("shop.word-for-trade-all-items", "all"))) {
+                    plugin.getConfig().getString("shop.word-for-trade-all-items", "all"))) {
                     int shopHaveSpaces =
-                            Util.countSpace(((ContainerShop) shop).getInventory(), shop.getItem());
+                        Util.countSpace(((ContainerShop) shop).getInventory(), shop.getItem());
                     int invHaveItems = Util.countItems(p.getInventory(), shop.getItem());
                     // Check if shop owner has enough money
-                    double ownerBalance = eco.getBalance(shop.getOwner(), shop.getLocation().getWorld(), shop.getCurrency());
+                    double ownerBalance = eco
+                        .getBalance(shop.getOwner(), shop.getLocation().getWorld(),
+                            shop.getCurrency());
                     int ownerCanAfford;
 
                     if (shop.getPrice() != 0) {
@@ -1250,43 +1263,48 @@ public class ShopManager {
                         if (shopHaveSpaces == 0) {
                             // when typed 'all' but the shop doesn't have any empty space
                             MsgUtil.sendMessage(
+                                p,
+                                MsgUtil.getMessage(
+                                    "shop-has-no-space",
                                     p,
-                                    MsgUtil.getMessage(
-                                            "shop-has-no-space",
-                                            p,
-                                            Integer.toString(shopHaveSpaces),
-                                            Util.getItemStackName(shop.getItem())));
+                                    Integer.toString(shopHaveSpaces),
+                                    Util.getItemStackName(shop.getItem())));
                             return;
                         }
                         if (ownerCanAfford == 0
-                                && (!shop.isUnlimited()
-                                || plugin.getConfig().getBoolean("shop.pay-unlimited-shop-owners"))) {
+                            && (!shop.isUnlimited()
+                            || plugin.getConfig().getBoolean("shop.pay-unlimited-shop-owners"))) {
                             // when typed 'all' but the shop owner doesn't have enough money to buy at least 1
                             // item (and shop isn't unlimited or pay-unlimited is true)
                             MsgUtil.sendMessage(
+                                p,
+                                MsgUtil.getMessage(
+                                    "the-owner-cant-afford-to-buy-from-you",
                                     p,
-                                    MsgUtil.getMessage(
-                                            "the-owner-cant-afford-to-buy-from-you",
-                                            p,
-                                            Objects.requireNonNull(format(shop.getPrice(), shop.getLocation().getWorld(), shop.getCurrency())),
-                                            Objects.requireNonNull(format(ownerBalance, shop.getLocation().getWorld(), shop.getCurrency()))));
+                                    Objects.requireNonNull(
+                                        format(shop.getPrice(), shop.getLocation().getWorld(),
+                                            shop.getCurrency())),
+                                    Objects.requireNonNull(
+                                        format(ownerBalance, shop.getLocation().getWorld(),
+                                            shop.getCurrency()))));
                             return;
                         }
                         // when typed 'all' but player doesn't have any items to sell
                         MsgUtil.sendMessage(
+                            p,
+                            MsgUtil.getMessage(
+                                "you-dont-have-that-many-items",
                                 p,
-                                MsgUtil.getMessage(
-                                        "you-dont-have-that-many-items",
-                                        p,
-                                        Integer.toString(amount),
-                                        Util.getItemStackName(shop.getItem())));
+                                Integer.toString(amount),
+                                Util.getItemStackName(shop.getItem())));
                         return;
                     }
                 } else {
                     // instead of output cancelled message (when typed neither integer or 'all'), just let
                     // player know that there should be positive number or 'all'
                     MsgUtil.sendMessage(p, MsgUtil.getMessage("not-a-integer", p, message));
-                    Util.debugLog("Receive the chat " + message + " and it format failed: " + e.getMessage());
+                    Util.debugLog(
+                        "Receive the chat " + message + " and it format failed: " + e.getMessage());
                     return;
                 }
             }
@@ -1296,8 +1314,9 @@ public class ShopManager {
                 amount = Integer.parseInt(message);
             } catch (NumberFormatException e) {
                 if (message.equalsIgnoreCase(
-                        plugin.getConfig().getString("shop.word-for-trade-all-items", "all"))) {
-                    int shopHaveItems = Util.countItems(((ContainerShop) shop).getInventory(), shop.getItem());
+                    plugin.getConfig().getString("shop.word-for-trade-all-items", "all"))) {
+                    int shopHaveItems = Util
+                        .countItems(((ContainerShop) shop).getInventory(), shop.getItem());
                     int invHaveSpaces = Util.countSpace(p.getInventory(), shop.getItem());
                     if (!shop.isUnlimited()) {
                         amount = Math.min(shopHaveItems, invHaveSpaces);
@@ -1308,28 +1327,34 @@ public class ShopManager {
                     }
                     // typed 'all', check if player has enough money than price * amount
                     double price = shop.getPrice();
-                    double balance = eco.getBalance(p.getUniqueId(), shop.getLocation().getWorld(), shop.getCurrency());
+                    double balance = eco.getBalance(p.getUniqueId(), shop.getLocation().getWorld(),
+                        shop.getCurrency());
                     amount = Math.min(amount, (int) Math.floor(balance / price));
                     if (amount < 1) { // typed 'all' but the auto set amount is 0
                         // when typed 'all' but player can't buy any items
                         if (!shop.isUnlimited() && shopHaveItems < 1) {
                             // but also the shop's stock is 0
                             MsgUtil.sendMessage(p, MsgUtil.getMessage("shop-stock-too-low", p,
-                                    Integer.toString(shop.getRemainingStock()),
-                                    Util.getItemStackName(shop.getItem())));
+                                Integer.toString(shop.getRemainingStock()),
+                                Util.getItemStackName(shop.getItem())));
                         } else {
                             // when if player's inventory is full
                             if (invHaveSpaces <= 0) {
-                                MsgUtil.sendMessage(p, MsgUtil.getMessage("not-enough-space", p, String.valueOf(invHaveSpaces)));
+                                MsgUtil.sendMessage(p, MsgUtil.getMessage("not-enough-space", p,
+                                    String.valueOf(invHaveSpaces)));
                                 return;
                             }
                             MsgUtil.sendMessage(
+                                p,
+                                MsgUtil.getMessage(
+                                    "you-cant-afford-to-buy",
                                     p,
-                                    MsgUtil.getMessage(
-                                            "you-cant-afford-to-buy",
-                                            p,
-                                            Objects.requireNonNull(format(price, shop.getLocation().getWorld(), shop.getCurrency())),
-                                            Objects.requireNonNull(format(balance, shop.getLocation().getWorld(), shop.getCurrency()))));
+                                    Objects.requireNonNull(
+                                        format(price, shop.getLocation().getWorld(),
+                                            shop.getCurrency())),
+                                    Objects.requireNonNull(
+                                        format(balance, shop.getLocation().getWorld(),
+                                            shop.getCurrency()))));
                         }
                         return;
                     }
@@ -1337,7 +1362,8 @@ public class ShopManager {
                     // instead of output cancelled message, just let player know that there should be positive
                     // number or 'all'
                     MsgUtil.sendMessage(p, MsgUtil.getMessage("not-a-integer", p, message));
-                    Util.debugLog("Receive the chat " + message + " and it format failed: " + e.getMessage());
+                    Util.debugLog(
+                        "Receive the chat " + message + " and it format failed: " + e.getMessage());
                     return;
                 }
             }
@@ -1349,7 +1375,7 @@ public class ShopManager {
     }
 
     private @Nullable Shop getShopIncludeAttached_Fast(
-            @NotNull Location loc, boolean fromAttach, boolean useCache) {
+        @NotNull Location loc, boolean fromAttach, boolean useCache) {
         Shop shop = getShop(loc);
 
         // failed, get attached shop
@@ -1364,7 +1390,8 @@ public class ShopManager {
                 if (Util.isWallSign(currentBlock.getType())) {
                     final Block attached = Util.getAttached(currentBlock);
                     if (attached != null) {
-                        shop = this.getShopIncludeAttached_Fast(attached.getLocation(), true, useCache);
+                        shop = this
+                            .getShopIncludeAttached_Fast(attached.getLocation(), true, useCache);
                     }
                     // double chest
                 } else {

--- a/src/main/java/org/maxgamer/quickshop/shop/ShopManager.java
+++ b/src/main/java/org/maxgamer/quickshop/shop/ShopManager.java
@@ -999,13 +999,12 @@ public class ShopManager {
             }
         }
 
-        // If this is a left shop, update the attached shop to fix the displayitem location.
-        if (shop.isRealDouble() && shop.isLeftShop()) {
-            Shop nextTo = shop.getAttachedShop();
-            Objects.requireNonNull(nextTo).refresh();
+        // If this is one of two double chests, update its partner too
+        if (shop.isRealDouble()) {
+            shop.getAttachedShop().refresh();
         }
-
-        shop.checkDisplay();
+        // One last refresh to ensure the item shows up
+        shop.refresh();
     }
 
     @Deprecated

--- a/src/main/java/org/maxgamer/quickshop/shop/VirtualDisplayItem.java
+++ b/src/main/java/org/maxgamer/quickshop/shop/VirtualDisplayItem.java
@@ -93,6 +93,10 @@ public class VirtualDisplayItem extends DisplayItem {
 
     private void initFakeDropItemPacket() {
 
+        if (shop.isLeftShop()) {
+            shop.getAttachedShop().refresh();
+            return;
+        }
         //First, create a new packet to spawn item
         fakeItemPacket = protocolManager.createPacket(PacketType.Play.Server.SPAWN_ENTITY);
 
@@ -269,8 +273,8 @@ public class VirtualDisplayItem extends DisplayItem {
     @Override
     public void respawn() {
         Util.ensureThread(false);
-        sendPacketToAll(fakeItemDestroyPacket);
-        sendFakeItemToAll();
+        remove();
+        spawn();
     }
 
     public void sendFakeItemToAll() {
@@ -287,7 +291,8 @@ public class VirtualDisplayItem extends DisplayItem {
     @Override
     public void spawn() {
         Util.ensureThread(false);
-        if (shop.isRealDouble() && shop.isLeftShop()) {
+        if (shop.isLeftShop()) {
+            shop.getAttachedShop().refresh();
             return;
         }
         if (shop.isDeleted() || !shop.isLoaded()) {
@@ -325,7 +330,7 @@ public class VirtualDisplayItem extends DisplayItem {
                 public void onPacketSending(@NotNull PacketEvent event) {
                     //is really full chunk data
                     boolean isFull = event.getPacket().getBooleans().read(0);
-                    if (!shop.isLoaded() || !isDisplay || !isFull || !Util.isLoaded(shop.getLocation())) {
+                    if (!shop.isLoaded() || !isDisplay || !isFull || !Util.isLoaded(shop.getLocation()) || shop.isLeftShop()) {
                         return;
                     }
                     //chunk x
@@ -410,6 +415,9 @@ public class VirtualDisplayItem extends DisplayItem {
 
     @Override
     public boolean isSpawned() {
+        if (shop.isLeftShop()) {
+            return (Objects.requireNonNull(shop.getAttachedShop().getDisplayItem())).isSpawned();
+        }
         return isDisplay;
     }
 

--- a/src/main/java/org/maxgamer/quickshop/shop/VirtualDisplayItem.java
+++ b/src/main/java/org/maxgamer/quickshop/shop/VirtualDisplayItem.java
@@ -94,7 +94,6 @@ public class VirtualDisplayItem extends DisplayItem {
     private void initFakeDropItemPacket() {
 
         if (shop.isLeftShop()) {
-            shop.getAttachedShop().refresh();
             return;
         }
         //First, create a new packet to spawn item

--- a/src/main/java/org/maxgamer/quickshop/shop/VirtualDisplayItem.java
+++ b/src/main/java/org/maxgamer/quickshop/shop/VirtualDisplayItem.java
@@ -287,6 +287,9 @@ public class VirtualDisplayItem extends DisplayItem {
     @Override
     public void spawn() {
         Util.ensureThread(false);
+        if (shop.isRealDouble() && shop.isLeftShop()) {
+            return;
+        }
         if (shop.isDeleted() || !shop.isLoaded()) {
             return;
         }
@@ -391,8 +394,18 @@ public class VirtualDisplayItem extends DisplayItem {
     }
 
     @Override
-    public @NotNull Location getDisplayLocation() {
-        return shop.getLocation().clone().add(0.5, 1.2, 0.5);
+    public Location getDisplayLocation() {
+        Util.ensureThread(false);
+        if (shop.isRealDouble()) {
+            if (shop.isLeftShop()) {
+                return null;
+            }
+            double avgX = (shop.getLocation().getX() + shop.getAttachedShop().getLocation().getX()) / 2;
+            double avgZ = (shop.getLocation().getZ() + shop.getAttachedShop().getLocation().getZ()) / 2;
+            Location newloc = new Location(shop.getLocation().getWorld(), avgX, shop.getLocation().getY(), avgZ, shop.getLocation().getYaw(), shop.getLocation().getPitch());
+            return newloc.add(0.5, 1.2, 0.5);
+        }
+        return this.shop.getLocation().clone().add(0.5, 1.2, 0.5);
     }
 
     @Override

--- a/src/main/java/org/maxgamer/quickshop/shop/VirtualDisplayItem.java
+++ b/src/main/java/org/maxgamer/quickshop/shop/VirtualDisplayItem.java
@@ -305,6 +305,14 @@ public class VirtualDisplayItem extends DisplayItem {
             return;
         }
         load();
+
+        // Can't rely on the attachedShop cache to be accurate
+        // So just try it and if it fails, no biggie
+        try {
+            shop.getAttachedShop().updateAttachedShop();
+        } catch (NullPointerException ignored) {
+        }
+
         sendFakeItemToAll();
         isDisplay = true;
     }

--- a/src/main/java/org/maxgamer/quickshop/shop/VirtualDisplayItem.java
+++ b/src/main/java/org/maxgamer/quickshop/shop/VirtualDisplayItem.java
@@ -292,7 +292,6 @@ public class VirtualDisplayItem extends DisplayItem {
     public void spawn() {
         Util.ensureThread(false);
         if (shop.isLeftShop()) {
-            shop.getAttachedShop().refresh();
             return;
         }
         if (shop.isDeleted() || !shop.isLoaded()) {
@@ -396,21 +395,6 @@ public class VirtualDisplayItem extends DisplayItem {
     @Override
     public @Nullable Entity getDisplay() {
         return null;
-    }
-
-    @Override
-    public Location getDisplayLocation() {
-        Util.ensureThread(false);
-        if (shop.isRealDouble()) {
-            if (shop.isLeftShop()) {
-                return null;
-            }
-            double avgX = (shop.getLocation().getX() + shop.getAttachedShop().getLocation().getX()) / 2;
-            double avgZ = (shop.getLocation().getZ() + shop.getAttachedShop().getLocation().getZ()) / 2;
-            Location newloc = new Location(shop.getLocation().getWorld(), avgX, shop.getLocation().getY(), avgZ, shop.getLocation().getYaw(), shop.getLocation().getPitch());
-            return newloc.add(0.5, 1.2, 0.5);
-        }
-        return this.shop.getLocation().clone().add(0.5, 1.2, 0.5);
     }
 
     @Override


### PR DESCRIPTION
Hi! This is my first contribution to this project, so any help would be appreciated in getting my code merged!

This PR resolves #807 
First, it checks for any situations where there is a double chest shop of the same item.
Then it finds the left block of that double chest (in relation to the chest's direction), and tells it not to spawn an item.
The right chest then spawns it's item centered between the two chests.

This removes the duplicate items of the same type for a double chest, especially useful when you want to buy and sell the same item from the same chest.

![2021-03-16_08 38 58](https://user-images.githubusercontent.com/34615968/111327577-1cd35c80-8633-11eb-8e48-7c3efaaafe57.png)

