### PR TITLE
Load tax account just once

### DIFF
--- a/src/main/java/org/maxgamer/quickshop/QuickShop.java
+++ b/src/main/java/org/maxgamer/quickshop/QuickShop.java
@@ -259,6 +259,8 @@ public class QuickShop extends JavaPlugin {
     private WorldEditAdapter worldEditAdapter;
     @Getter
     private GameVersion gameVersion;
+    @Getter
+    private OfflinePlayer taxAccount;
 
     @NotNull
     public static QuickShop getInstance() {
@@ -523,6 +525,9 @@ public class QuickShop extends JavaPlugin {
         } else {
             logWatcher = null;
         }
+        this.taxAccount = this.getServer().getOfflinePlayer(
+          Objects.requireNonNull(this.getConfig().getString("tax-account"))
+        );
     }
 
     /**

--- a/src/main/java/org/maxgamer/quickshop/QuickShop.java
+++ b/src/main/java/org/maxgamer/quickshop/QuickShop.java
@@ -259,8 +259,6 @@ public class QuickShop extends JavaPlugin {
     private WorldEditAdapter worldEditAdapter;
     @Getter
     private GameVersion gameVersion;
-    @Getter
-    private OfflinePlayer taxAccount;
 
     @NotNull
     public static QuickShop getInstance() {
@@ -525,9 +523,6 @@ public class QuickShop extends JavaPlugin {
         } else {
             logWatcher = null;
         }
-        this.taxAccount = this.getServer().getOfflinePlayer(
-          Objects.requireNonNull(this.getConfig().getString("tax-account"))
-        );
     }
 
     /**

--- a/src/main/java/org/maxgamer/quickshop/command/subcommand/SubCommand_Price.java
+++ b/src/main/java/org/maxgamer/quickshop/command/subcommand/SubCommand_Price.java
@@ -161,7 +161,7 @@ public class SubCommand_Price implements CommandProcesser {
                     plugin
                             .getEconomy()
                             .deposit(
-                                    plugin.getTaxAccount(),
+                                    plugin.getShopManager().getCacheTaxAccount(),
                                     fee, shop.getLocation().getWorld(), shop.getCurrency());
                 } catch (Exception e) {
                     plugin.getLogger().log(Level.WARNING, "QuickShop can't pay taxes to the configured tax account! Please set the tax account name in the config.yml to an existing player!", e);

--- a/src/main/java/org/maxgamer/quickshop/command/subcommand/SubCommand_Price.java
+++ b/src/main/java/org/maxgamer/quickshop/command/subcommand/SubCommand_Price.java
@@ -158,15 +158,10 @@ public class SubCommand_Price implements CommandProcesser {
                         MsgUtil.getMessage(
                                 "fee-charged-for-price-change", sender, plugin.getEconomy().format(fee, shop.getLocation().getWorld(), shop.getCurrency())));
                 try {
-                    //noinspection deprecation
                     plugin
                             .getEconomy()
                             .deposit(
-                                    plugin
-                                            .getServer()
-                                            .getOfflinePlayer(
-                                                    Objects.requireNonNull(plugin.getConfig().getString("tax-account")))
-                                            .getUniqueId(),
+                                    plugin.getTaxAccount(),
                                     fee, shop.getLocation().getWorld(), shop.getCurrency());
                 } catch (Exception e) {
                     plugin.getLogger().log(Level.WARNING, "QuickShop can't pay taxes to the configured tax account! Please set the tax account name in the config.yml to an existing player!", e);

--- a/src/main/java/org/maxgamer/quickshop/shop/ShopManager.java
+++ b/src/main/java/org/maxgamer/quickshop/shop/ShopManager.java
@@ -65,6 +65,7 @@ public class ShopManager {
     private final Map<UUID, Info> actions = Maps.newConcurrentMap();
 
     private final QuickShop plugin;
+    @Getter
     private final Trader cacheTaxAccount;
     @Getter
     private final PriceLimiter priceLimiter;


### PR DESCRIPTION
We found that the OfflinePlayer lookup here could stall the main thread on networking, as each time it would have to retrieve data about the player from Mojang. This PR loads the OfflinePlayer just once when the configuration is loaded, and keeps it cached.