### PR TITLE
4.0.9.5 (#1271)

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 11
+      - name: Set up JDK 16
         uses: actions/setup-java@v2
         with:
           java-version: '16'

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <artifactId>QuickShop</artifactId>
 
     <properties>
-        <pluginver>4.0.9.4</pluginver>
+        <pluginver>4.0.9.5</pluginver>
         <package>org.maxgamer.quickshop</package>
         <developer>Ghost-chu</developer>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -459,7 +459,7 @@
         <dependency>
             <groupId>com.comphenix.protocol</groupId>
             <artifactId>ProtocolLib</artifactId>
-            <version>4.6.0</version>
+            <version>4.7.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/maxgamer/quickshop/QuickShop.java
+++ b/src/main/java/org/maxgamer/quickshop/QuickShop.java
@@ -1852,6 +1852,12 @@ public class QuickShop extends JavaPlugin {
             getConfig().set("unlimited-shop-owner-change-account", "quickshop");
             getConfig().set("config-version", ++selectedVersion);
         }
+        if (selectedVersion == 132) {
+            getConfig().set("shop.sign-glowing", false);
+            getConfig().set("shop.sign-dye-color", "null");
+            getConfig().set("unlimited-shop-owner-change-account", "quickshop");
+            getConfig().set("config-version", ++selectedVersion);
+        }
 
 
         if (getConfig().getInt("matcher.work-type") != 0 && GameVersion.get(ReflectFactory.getServerVersion()).name().contains("1_16")) {

--- a/src/main/java/org/maxgamer/quickshop/command/CommandManager.java
+++ b/src/main/java/org/maxgamer/quickshop/command/CommandManager.java
@@ -474,7 +474,6 @@ public class CommandManager implements TabCompleter, CommandExecutor {
 
     private boolean isAdapt(CommandContainer container, CommandSender sender) {
         return container.getExecutorType().isInstance(sender);
-
     }
 
     @Override

--- a/src/main/java/org/maxgamer/quickshop/listener/BlockListener.java
+++ b/src/main/java/org/maxgamer/quickshop/listener/BlockListener.java
@@ -34,6 +34,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.event.block.SignChangeEvent;
 import org.bukkit.event.inventory.InventoryMoveItemEvent;
 import org.bukkit.inventory.Inventory;
 import org.jetbrains.annotations.NotNull;
@@ -156,7 +157,6 @@ public class BlockListener extends ProtectionListenerBase {
         if (b == null) {
             return null;
         }
-
         return getShopPlayer(b.getLocation(), false);
     }
 
@@ -180,6 +180,25 @@ public class BlockListener extends ProtectionListenerBase {
         }
     }
 
+    /*
+     * Listens for sign update to prevent other plugin or Purpur to edit the sign
+     */
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.LOWEST)
+    public void onSignUpdate(SignChangeEvent event) {
+        Block posShopBlock = Util.getAttached(event.getBlock());
+        if (posShopBlock == null) {
+            return;
+        }
+        Shop shop = plugin.getShopManager().getShopIncludeAttached(posShopBlock.getLocation());
+        if (shop == null) {
+            return;
+        }
+        Player player = event.getPlayer();
+        if (!shop.getModerator().isModerator(player.getUniqueId())) {
+            MsgUtil.sendMessage(player, "not-managed-shop");
+            event.setCancelled(true);
+        }
+    }
 
     /*
      * Listens for chest placement, so a doublechest shop can't be created.

--- a/src/main/java/org/maxgamer/quickshop/listener/LockListener.java
+++ b/src/main/java/org/maxgamer/quickshop/listener/LockListener.java
@@ -107,6 +107,30 @@ public class LockListener extends ProtectionListenerBase {
         }
     }
 
+    /*
+     * Listens for sign placement to prevent placing sign for creating protection
+     */
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.LOWEST)
+    public void onSignPlace(BlockPlaceEvent event) {
+        Block placedBlock = event.getBlock();
+        if (!(placedBlock.getState() instanceof Sign)) {
+            return;
+        }
+        Block posShopBlock = Util.getAttached(placedBlock);
+        if (posShopBlock == null) {
+            return;
+        }
+        Shop shop = plugin.getShopManager().getShopIncludeAttached(posShopBlock.getLocation());
+        if (shop == null) {
+            return;
+        }
+        Player player = event.getPlayer();
+        if (!shop.getModerator().isOwner(player.getUniqueId())) {
+            MsgUtil.sendMessage(player, "that-is-locked");
+            event.setCancelled(true);
+        }
+    }
+
     @EventHandler(ignoreCancelled = true)
     public void onClick(PlayerInteractEvent e) {
 

--- a/src/main/java/org/maxgamer/quickshop/listener/ShopProtectionListener.java
+++ b/src/main/java/org/maxgamer/quickshop/listener/ShopProtectionListener.java
@@ -115,13 +115,10 @@ public class ShopProtectionListener extends ProtectionListenerBase {
                 plugin.getLogger().log(Level.WARNING, "Failed to automatic disable disable-move-event for world [" + world.getName() + "], please disable it by yourself or player can steal items from shops.", ex);
             }
         });
-
-
     }
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onBlockExplode(BlockExplodeEvent e) {
-
         for (int i = 0, a = e.blockList().size(); i < a; i++) {
             final Block b = e.blockList().get(i);
             Shop shop = getShopNature(b.getLocation(), true);

--- a/src/main/java/org/maxgamer/quickshop/shop/ContainerShop.java
+++ b/src/main/java/org/maxgamer/quickshop/shop/ContainerShop.java
@@ -22,10 +22,7 @@ package org.maxgamer.quickshop.shop;
 import com.lishid.openinv.OpenInv;
 import io.papermc.lib.PaperLib;
 import lombok.EqualsAndHashCode;
-import org.bukkit.ChatColor;
-import org.bukkit.Location;
-import org.bukkit.Material;
-import org.bukkit.OfflinePlayer;
+import org.bukkit.*;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.BlockState;
@@ -679,12 +676,24 @@ public class ContainerShop implements Shop {
     public void setSignText(@NotNull String[] lines) {
         Util.ensureThread(false);
         List<Sign> signs = this.getSigns();
+        boolean signGlowing = plugin.getConfig().getBoolean("shop.sign-glowing");
+        DyeColor dyeColor = null;
+        try {
+            dyeColor = DyeColor.valueOf(plugin.getConfig().getString("shop.sign-dye-color"));
+        } catch (IllegalArgumentException ignored) {
+        }
         for (Sign sign : signs) {
             if (Arrays.equals(sign.getLines(), lines)) {
                 continue;
             }
             for (int i = 0; i < lines.length; i++) {
                 sign.setLine(i, lines[i]);
+            }
+            if (plugin.getGameVersion().isSignTextDyeSupport() && dyeColor != null) {
+                sign.setColor(dyeColor);
+            }
+            if (signGlowing && plugin.getGameVersion().isSignGlowingSupport()) {
+                sign.setGlowingText(true);
             }
             sign.update(true);
             plugin.getServer().getPluginManager().callEvent(new ShopSignUpdateEvent(this, sign));

--- a/src/main/java/org/maxgamer/quickshop/shop/ShopLoader.java
+++ b/src/main/java/org/maxgamer/quickshop/shop/ShopLoader.java
@@ -87,6 +87,7 @@ public class ShopLoader {
         this.plugin.getLogger().info("Loading shops from the database...");
         int loadAfterChunkLoaded = 0;
         int loadAfterWorldLoaded = 0;
+        List<Shop> pendingLoadShops = new ArrayList<>();
         try (WarpedResultSet warpRS = plugin.getDatabaseHelper().selectAllShops(); ResultSet rs = warpRS.getResultSet()) {
             while (rs.next()) {
                 ShopRawDatabaseInfo origin = new ShopRawDatabaseInfo(rs);
@@ -140,11 +141,14 @@ public class ShopLoader {
                         //TODO: Old shop will be deleted when in same location creating new shop.
                         continue;
                     }
-                    shop.onLoad();
-                    shop.update();
+                    pendingLoadShops.add(shop);
                 } else {
                     loadAfterChunkLoaded++;
                 }
+            }
+            for (Shop shop : pendingLoadShops) {
+                shop.onLoad();
+                shop.update();
             }
             this.plugin
                     .getLogger()

--- a/src/main/java/org/maxgamer/quickshop/shop/VirtualDisplayItem.java
+++ b/src/main/java/org/maxgamer/quickshop/shop/VirtualDisplayItem.java
@@ -27,6 +27,7 @@ import com.comphenix.protocol.events.PacketContainer;
 import com.comphenix.protocol.events.PacketEvent;
 import com.comphenix.protocol.injector.server.TemporaryPlayer;
 import com.comphenix.protocol.reflect.StructureModifier;
+import com.comphenix.protocol.utility.MinecraftVersion;
 import com.comphenix.protocol.wrappers.WrappedChatComponent;
 import com.comphenix.protocol.wrappers.WrappedDataWatcher;
 import org.bukkit.Chunk;
@@ -456,9 +457,21 @@ public class VirtualDisplayItem extends DisplayItem {
                 //Entity to remove
                 fakeItemDestroyPacket.getIntegerArrays().write(0, new int[]{entityID});
             } else {
-                //On 1.17 (may be 1.17+?), just need to write a int
-                //Entity to remove
-                fakeItemDestroyPacket.getIntegers().write(0, entityID);
+                //1.17+
+                MinecraftVersion minecraftVersion = protocolManager.getMinecraftVersion();
+                if (minecraftVersion.getMajor() == 1 && minecraftVersion.getMinor() == 17 && minecraftVersion.getBuild() == 0) {
+                    //On 1.17, just need to write a int
+                    //Entity to remove
+                    fakeItemDestroyPacket.getIntegers().write(0, entityID);
+                } else {
+                    //On 1.17.1 (may be 1.17.1+? it's enough, Mojang, stop the changes), we need add the int list
+                    //Entity to remove
+                    try {
+                        fakeItemDestroyPacket.getIntLists().write(0, Collections.singletonList(entityID));
+                    } catch (NoSuchMethodError e) {
+                        throw new RuntimeException("Unable to initialize packet, ProtocolLib update needed", e);
+                    }
+                }
             }
             return fakeItemDestroyPacket;
         }

--- a/src/main/java/org/maxgamer/quickshop/util/GameVersion.java
+++ b/src/main/java/org/maxgamer/quickshop/util/GameVersion.java
@@ -19,6 +19,8 @@
 
 package org.maxgamer.quickshop.util;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -26,38 +28,40 @@ import org.jetbrains.annotations.NotNull;
  *
  * @author Ghost_chu and sandtechnology
  */
+@AllArgsConstructor
+@Getter
 public enum GameVersion {
-    v1_5_R1(false, false, false, false),
-    v1_5_R2(false, false, false, false),
-    v1_5_R3(false, false, false, false),
-    v1_6_R1(false, false, false, false),
-    v1_6_R2(false, false, false, false),
-    v1_6_R3(false, false, false, false),
-    v1_7_R1(false, false, false, false),
-    v1_7_R2(false, false, false, false),
-    v1_7_R3(false, false, false, false),
-    v1_7_R4(false, false, false, false),
-    v1_8_R1(false, false, false, false),
-    v1_8_R2(false, false, false, false),
-    v1_8_R3(false, false, false, false),
-    v1_9_R1(false, false, false, false),
-    v1_9_R2(false, false, false, false),
-    v1_10_R1(false, false, false, false),
-    v1_11_R1(false, false, false, false),
-    v1_12_R1(false, false, false, false),
-    v1_12_R2(false, false, false, false),
-    v1_13_R1(false, false, false, false),
-    v1_13_R2(true, true, false, false),
-    v1_14_R1(true, true, true, false),
-    v1_14_R2(true, true, true, false),
-    v1_15_R1(true, true, true, false),
-    v1_15_R2(true, true, true, false),
-    v1_16_R1(true, true, true, false),
-    v1_16_R2(true, true, true, false),
-    v1_16_R3(true, true, true, false),
-    v1_16_R4(true, true, true, false),
-    v1_17_R1(true, true, true, true),
-    UNKNOWN(true, true, true, true);
+    v1_5_R1(false, false, false, false, false, false),
+    v1_5_R2(false, false, false, false, false, false),
+    v1_5_R3(false, false, false, false, false, false),
+    v1_6_R1(false, false, false, false, false, false),
+    v1_6_R2(false, false, false, false, false, false),
+    v1_6_R3(false, false, false, false, false, false),
+    v1_7_R1(false, false, false, false, false, false),
+    v1_7_R2(false, false, false, false, false, false),
+    v1_7_R3(false, false, false, false, false, false),
+    v1_7_R4(false, false, false, false, false, false),
+    v1_8_R1(false, false, false, false, false, false),
+    v1_8_R2(false, false, false, false, false, false),
+    v1_8_R3(false, false, false, false, false, false),
+    v1_9_R1(false, false, false, false, false, false),
+    v1_9_R2(false, false, false, false, false, false),
+    v1_10_R1(false, false, false, false, false, false),
+    v1_11_R1(false, false, false, false, false, false),
+    v1_12_R1(false, false, false, false, false, false),
+    v1_12_R2(false, false, false, false, false, false),
+    v1_13_R1(false, false, false, false, false, false),
+    v1_13_R2(true, true, false, false, false, false),
+    v1_14_R1(true, true, true, false, false, false),
+    v1_14_R2(true, true, true, false, false, false),
+    v1_15_R1(true, true, true, false, false, false),
+    v1_15_R2(true, true, true, false, false, false),
+    v1_16_R1(true, true, true, false, false, false),
+    v1_16_R2(true, true, true, false, false, false),
+    v1_16_R3(true, true, true, false, false, false),
+    v1_16_R4(true, true, true, false, false, false),
+    v1_17_R1(true, true, true, true, true, true),
+    UNKNOWN(true, true, true, true, true, true);
     /**
      * CoreSupports - Check does QuickShop most features supports this server version
      */
@@ -76,18 +80,15 @@ public enum GameVersion {
     private final boolean newNmsName;
 
     /**
-     * Utilities to help QuickShop quickly check server supported features
-     *
-     * @param coreSupports                 Does QuickShop most features supports this server version
-     * @param virtualDisplaySupports       Does QuickShop VirtualDisplayItem feature this server version
-     * @param persistentStorageApiSupports Does server support PersistentStorage API
+     * Sign Glowing Support
      */
-    GameVersion(boolean coreSupports, boolean virtualDisplaySupports, boolean persistentStorageApiSupports, boolean newNmsName) {
-        this.coreSupports = coreSupports;
-        this.virtualDisplaySupports = virtualDisplaySupports;
-        this.persistentStorageApiSupports = persistentStorageApiSupports;
-        this.newNmsName = newNmsName;
-    }
+    private final boolean signGlowingSupport;
+
+    /**
+     * Sign Glowing Support
+     */
+    private final boolean signTextDyeSupport;
+
 
     /**
      * Matches the version that QuickShop supports or not
@@ -105,19 +106,4 @@ public enum GameVersion {
         return UNKNOWN;
     }
 
-    public boolean isCoreSupports() {
-        return coreSupports;
-    }
-
-    public boolean isVirtualDisplaySupports() {
-        return virtualDisplaySupports;
-    }
-
-    public boolean isPersistentStorageApiSupports() {
-        return persistentStorageApiSupports;
-    }
-
-    public boolean isNewNmsName() {
-        return newNmsName;
-    }
 }

--- a/src/main/java/org/maxgamer/quickshop/util/Util.java
+++ b/src/main/java/org/maxgamer/quickshop/util/Util.java
@@ -831,10 +831,7 @@ public class Util {
     }
 
     public static boolean isDisplayAllowBlock(@NotNull Material mat) {
-        if (isAir(mat)) {
-            return true;
-        }
-        return isWallSign(mat);
+        return mat.isTransparent();
     }
 
     public static boolean isAir(@NotNull Material mat) {

--- a/src/main/java/org/maxgamer/quickshop/util/envcheck/EnvironmentChecker.java
+++ b/src/main/java/org/maxgamer/quickshop/util/envcheck/EnvironmentChecker.java
@@ -216,10 +216,6 @@ public final class EnvironmentChecker {
                 }
             }
         }
-
-        //tool.verify()
-
-
     }
 
     @EnvCheckEntry(name = "EnvChecker SelfTest", priority = 1)

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -22,7 +22,7 @@
 #                        TO EDIT QUICKSHOP'S CONFIGURATION, USE THE "config.yml" FILE!
 
 #Do not touch this if you don't know what you're doing!
-config-version: 132
+config-version: 133
 
 #Select the language you want to use, (e.g de), use only supported language codes from the list below.
 #If you use a not existant/not supported language, then QuickShop will use en_US.
@@ -264,6 +264,13 @@ shop:
 
   #Should we automatically create the sign for the chest?
   auto-sign: true
+
+  #Sign use glowing effects
+  sign-glowing: false
+
+  #Sign use dye color  https://hub.spigotmc.org/javadocs/spigot/org/bukkit/DyeColor.html
+  sign-dye-color: null
+  #sign-dye-color: WHITE
 
   #Should we pay/take money to/from unlimited shops owners?
   pay-unlimited-shop-owners: false

--- a/src/main/resources/lang/es-ES/messages.json
+++ b/src/main/resources/lang/es-ES/messages.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Hi translator! If you editing this from Github or from code sources, you should go https://crowdin.com/project/quickshop-reremake",
+  "_comment": "¡Hola traductor! Si editas esto desde Github o desde código fuente, deberías ir a https://crowdin.com/project/quickshop-reremake",
   "file-test": "Este es un archivo de texto de prueba. Lo usamos para probar si el messages.json está roto. Puedes llenarlo con los huevos de pascua que quieras aquí :)",
   "translation-author": "Traductor: Ghost_chu, Andre_601, MarcosTheFasdox",
   "translation-version": "&c&lVersión soportada: &b&lReremake",
@@ -45,7 +45,7 @@
   "fee-charged-for-price-change": "&aHas pagado &c{0}&a para cambiar de precio.",
   "price-is-now": "&aEl nuevo precio de la tienda es &e{0}",
   "thats-not-a-number": "&cNúmero inválido.",
-  "forbidden-vanilla-behavior": "&cThe operation is forbidden due to it not being consisten with vanilla behaviour",
+  "forbidden-vanilla-behavior": "&cLa operación está prohibida por no ser compatible con el comportamiento vainilla",
   "no-price-given": "&cPor favor ingresa un precio válido.",
   "average-price-nearby": "&aPrecio medio en esta zona: &e{0}",
   "shop-has-changed": "&c¡La tienda que trataste de usar ha cambiado desde que hiciste clic!",
@@ -139,7 +139,7 @@
     "no-amount-given": "&cNo se especificó cantidad. Usa &a/qs refill <amount>&c",
     "now-debuging": "&aModo desarrollador habilitado. Recargando QuickShop...",
     "now-nolonger-debuging": "&aModo desarrollador deshabilitado. Recargando QuickShop...",
-    "wrong-args": "&cInvalid argument. Use &l/qs help &cto see a list of commands.",
+    "wrong-args": "&cArgumento no válido. Usa la ayuda &l/qs &cpara ver una lista de comandos.",
     "description": {
       "title": "&aAyuda de QuickShop",
       "unlimited": "&eDa un stock ilimitado a una tienda.",

--- a/src/main/resources/lang/fi-FI/messages.json
+++ b/src/main/resources/lang/fi-FI/messages.json
@@ -78,7 +78,7 @@
   "no-permission-build": "&cEt voi rakentaa kauppaa tähän.",
   "success-change-owner-to-server": "&aOnnistuneesti vaihdettu kaupan omistaja palvelimeen.",
   "flush-finished": "&aViestit päivitettiin onnistuneesti.",
-  "purchase-failed": "&cOsto epäonnistui: Sisäinen ongelme. Ota yhteyttä palvelimen järjestelmänvalvojaan.",
+  "purchase-failed": "&cOsto epäonnistui: Sisäinen virhe. Ota yhteyttä palvelimen ylläpitoon.",
   "no-pending-action": "&cSinulla ei ole mitään odottavia toimintapyyntöjä",
   "permission-denied-3rd-party": "&cOikeus kielletty: kolmannen osapuolen lisäosa [{0}].",
   "shops-removed-in-world": "&eYhteensä &b{0}&e kauppa(a) on poistettu maailmasta &b{1}&e.",

--- a/src/main/resources/lang/ja-JP/messages.json
+++ b/src/main/resources/lang/ja-JP/messages.json
@@ -193,7 +193,7 @@
     "status-unavailable": "&c",
     "out-of-stock": "Out of Stock",
     "out-of-space": "Out of Space",
-    "freeze": "Trading disabled"
+    "freeze": "取引が無効化されました。"
   },
   "controlpanel": {
     "setowner": "&aオーナー: &b{0} &e[&d&l変更&e]",

--- a/src/main/resources/lang/ru-RU/messages.json
+++ b/src/main/resources/lang/ru-RU/messages.json
@@ -1,7 +1,7 @@
 {
-  "_comment": "Hi translator! If you editing this from Github or from code sources, you should go https://crowdin.com/project/quickshop-reremake",
+  "_comment": "Привет переводчик! Если вы редактируете это с Github или из исходных кодов, вы должны перейти сюда https://crowdin.com/project/quickshop-reremake",
   "file-test": "Это тестовый файл. Мы используем его, если файл messages.json поломан. Вы тут можете заполнить любым пасхальными яйцами, которые вам нравятся здесь :)",
-  "translation-author": "Переводчик: Ghost_chu, Andre_601",
+  "translation-author": "Переводчик: Ghost_chu, Andre_601, kyrtion, limbiz86",
   "translation-version": "Поддерживаемая версия: Reremake",
   "translation-contributors": "Участники: Timtower, Netherfoam, KaiNoMood, Mgazul, JackTheChicken и Andre_601",
   "translation-country": "Языковой регион: Русский (ru_RU)",
@@ -45,7 +45,7 @@
   "fee-charged-for-price-change": "&aВы заплатили &c{0}&a за изменения цены.",
   "price-is-now": "&aНовая цена магазина &e{0}",
   "thats-not-a-number": "&cНеверное значение",
-  "forbidden-vanilla-behavior": "&cThe operation is forbidden due to it not being consisten with vanilla behaviour",
+  "forbidden-vanilla-behavior": "&cОперация отклонена, она не соответствует ванильному поведению",
   "no-price-given": "&cПожалуйста укажите верную цену.",
   "average-price-nearby": "&aСредняя цена: &e{0}",
   "shop-has-changed": "&cМагазин, который вы пытались использовать, изменился с момента нажатия!",
@@ -139,7 +139,7 @@
     "no-amount-given": "&cКоличество не указано. Используйте: &a/qs refill <количество>&c",
     "now-debuging": "&aУспешно включено режим разработчика. Перезагружаю...",
     "now-nolonger-debuging": "&aУспешно выключен режим разработчика. Перезагружаю...",
-    "wrong-args": "&cInvalid argument. Use &l/qs help &cto see a list of commands.",
+    "wrong-args": "&cНедопустимые аргументы. Используйте &l/qs help &cчтобы узнать список командов.",
     "description": {
       "title": "&aQuickShop справка",
       "unlimited": "&eПредоставляет неограниченный запас магазина.",
@@ -170,14 +170,14 @@
       "removeall": "&eУдалить ВСЕ магазины указанного игрока",
       "transfer": "&eПередайте кого-нибудь ВСЕ магазины в другие",
       "removeworld": "&eУдалить ВСЕ магазины в указанном мире",
-      "currency": "&eSet or remove the currency setting of the shop",
-      "ban": "&eBans a player from the shop",
-      "unban": "&eUnbans a player from the shop",
-      "freeze": "&eDisable or Enable shop trading",
-      "lock": "&eSwitch the shop's lock status"
+      "currency": "&eУстанавливает или удаляет настройки валюты магазина",
+      "ban": "&eЗапретить игрока из магазина",
+      "unban": "&eРазрешить игрока из магазина",
+      "freeze": "&eОтключить или включить торговлю в магазине",
+      "lock": "&eПереключить состояние блокировки магазина"
     },
     "disabled": "&cДанная команда недоступна: &e{0}",
-    "feature-not-enabled": "This feature is not enabled in the config file."
+    "feature-not-enabled": "Функция не включена в конфигурации."
   },
   "signs": {
     "selling": "Продаёт {0}",
@@ -191,9 +191,9 @@
     "unlimited": "∞",
     "status-available": "&a",
     "status-unavailable": "&c",
-    "out-of-stock": "Out of Stock",
-    "out-of-space": "Out of Space",
-    "freeze": "Trading disabled"
+    "out-of-stock": "Нет в наличии",
+    "out-of-space": "Не хватает места",
+    "freeze": "Торговля отключена"
   },
   "controlpanel": {
     "setowner": "&aВладелец: &b{0} &e[&d&lИзменить&e]",
@@ -219,10 +219,10 @@
     "item-hover": "&eНажмите, чтобы изменить магазин товара",
     "currency": "&aВалюта: &b{0} &e[&d&lУстановить&e]",
     "currency-hover": "&eНажмите, чтобы установить или удалить валюту, которую этот магазин использует",
-    "lock": "&eShop lock: &b{0} &e[&d&lToggle&e]",
-    "lock-hover": "&eEnable/Disable the shop's lock protection.",
-    "freeze": "&eFreeze mode: &b{0} &e[&d&lToggle&e]",
-    "freeze-hover": "&eToggle the shop's freeze status."
+    "lock": "&eМагазин заблокирован: &b{0} &e[&d&lПереключить&e]",
+    "lock-hover": "&eВключить/отключить защиту блокировки магазина.",
+    "freeze": "&eЗаморожен: &b{0} &e[&d&lПереключить&e]",
+    "freeze-hover": "&eПереключить статус заморозки магазина."
   },
   "tableformat": {
     "full_line": "+---------------------------------------------------+",
@@ -264,7 +264,7 @@
       "Доктор, QuickShop уже есть новое обновление {0}! Вы должны обновить~",
       "Ко~ко~да~ё~ QuickShop появились новое обновление {0} ~"
     ],
-    "remote-disable-warning": "&cThis version of QuickShop is marked as disabled by the remote server, which means this version may have serious problem, get details from our SpigotMC page: {0}. This warning will continue to appear until you switch to a stable version, but it will not affect your server's performance.",
+    "remote-disable-warning": "&cТекущая версия QuickShop отмечена как отключенная удалённым сервером, означая, что эта версия может иметь серьезные проблемы, получить подробную информацию с нашей страницы плагина SpigotMC: {0}. Это предупреждение будет отображаться до тех пор, пока вы не переключитесь на стабильную версию, но это не повлияет на перфорирование вашего сервера.",
     "label": {
       "unstable": "[Нестабильный]",
       "stable": "[Стабильный]",
@@ -313,15 +313,15 @@
   "currency-unset": "&aМагазин успешно удалён. Использование настроек теперь по умолчанию.",
   "currency-not-support": "&cПлагин экономики не поддерживает функцию несколько экономики.",
   "item-not-exist": "&cТовар &e{0} &cне существует, проверьте правильность написания.",
-  "backup-success": "&aBackup successfull.",
-  "console-only": "&cThis command can only be executed by Console.",
-  "console-only-danger": "&cThis is a dangerous command, so that only the Console can execute it.",
-  "clean-warning": "&eThis command will purge &call &eshops if the shop is damaged, was created in not allowed worlds, is selling/buying not allowed items or &c&lEXISTS IN A UNLOADED WORLD&e. Make sure to create a full backup of your shop data first and use &b/qs cleanghost confirm &eto continue.",
-  "shop-creation-failed": "&cShop creation failed, please contact with server administrator.",
-  "shop-owner-self-trade": "&eYou trading with yourself shop, so you might won't gain any balance.",
-  "chest-title": "QuickShop Store",
-  "command-type-mismatch": "&cThis command only can executed by &b{0}.",
-  "unlimited-shop-owner-changed": "&eThis unlimited shop owner has been changed to {0}.",
-  "unlimited-shop-owner-keeped": "&eAttention: The shop owner still is unlimited shop owner, you need re-set new shop owner by yourself.",
-  "server-crash-warning": "&cServer may crash after execute /qs reload command if you replace/delete QuickShop plugin Jar file while server running."
+  "backup-success": "&aРезервное копирование успешно.",
+  "console-only": "&cЭта команда может быть выполнена только консолью.",
+  "console-only-danger": "&cЭто опасная команда, поэтому только консоль может ее выполнить.",
+  "clean-warning": "&eЭта команда очистит &cвсех &eмагазинов, если магазин повреждён или создан в запрещённых мирах или продажах/покупке запрещенных товаров и &c&lНЕ ЗАГРУЖЕНА МИРА МАГАЗИНОВ&e, убедитесь, что у вас есть полная резервная копия данных ваших магазинов и используйте &b/qs cleanghost confirm &eдля продолжение.",
+  "shop-creation-failed": "&cНе удалось создать новый магазин, свяжитесь с администратором сервера.",
+  "shop-owner-self-trade": "&eВы торгуете с собственным магазином и не получите никакого баланса.",
+  "chest-title": "Магазин QuickShop",
+  "command-type-mismatch": "&cЭта команда может выполнена только &b{0}.",
+  "unlimited-shop-owner-changed": "&eЭтот владелец безлимитного магазина был изменен на {0}.",
+  "unlimited-shop-owner-keeped": "&eВнимание: Владелец магазина все еще является владельцем безлимитного магазина, вам нужно установить нового владельца магазина самостоятельно.",
+  "server-crash-warning": "&cСервер может вызывать сбой после выполнения команды /qs reload, если вы заменяете/удаляете плагина QuickShop во время работы сервера."
 }

--- a/src/main/resources/lang/zh-CN/messages.json
+++ b/src/main/resources/lang/zh-CN/messages.json
@@ -321,7 +321,7 @@
   "shop-owner-self-trade": "&e你正在和自己的商店进行交易，你可能不会得到任何钱。",
   "chest-title": "QuickShop商店",
   "command-type-mismatch": "&c此命令只能由 &b{0} 执行。",
-  "unlimited-shop-owner-changed": "&e这个系统商店的店主已更改为 {0}。",
+  "unlimited-shop-owner-changed": "&e这个无限商店的店主已更改为 {0}。",
   "unlimited-shop-owner-keeped": "&e请注意: 商店持有人依然是无限商店类型, 你需要重新设置新的商店",
-  "server-crash-warning": "如果服务器运行时替换/删除QuickShop插件 Jar 文件，&c服务器可能在执行 /qs 重新加载命令后崩溃。"
+  "server-crash-warning": "&c如果服务器运行时替换/删除QuickShop插件 Jar 文件，执行 /qs reload后服务器可能会崩溃。"
 }


### PR DESCRIPTION
* Update from release bunch (#1158)

Co-authored-by: Ghost_chu <30802565+Ghost-chu@users.noreply.github.com>

* New translations messages.json (Romanian)

* New translations messages.json (Dutch)

* New translations messages.json (Portuguese, Brazilian)

* New translations messages.json (Vietnamese)

* New translations messages.json (English)

* New translations messages.json (Chinese Traditional)

* New translations messages.json (Chinese Simplified)

* New translations messages.json (Ukrainian)

* New translations messages.json (Turkish)

* New translations messages.json (Swedish)

* New translations messages.json (Serbian (Cyrillic))

* New translations messages.json (Russian)

* New translations messages.json (Portuguese)

* New translations messages.json (Polish)

* New translations messages.json (Norwegian)

* New translations messages.json (Korean)

* New translations messages.json (French)

* New translations messages.json (Japanese)

* New translations messages.json (Italian)

* New translations messages.json (Hungarian)

* New translations messages.json (Hebrew)

* New translations messages.json (Finnish)

* New translations messages.json (Greek)

* New translations messages.json (German)

* New translations messages.json (Danish)

* New translations messages.json (Czech)

* New translations messages.json (Catalan)

* New translations messages.json (Arabic)

* New translations messages.json (Afrikaans)

* New translations messages.json (Spanish)

* New translations messages.json (Chinese Traditional, Hong Kong)

* New translations messages.json (Swedish)

* New translations messages.json (Czech)

* New translations messages.json (Norwegian)

* New translations messages.json (Chinese Simplified)

* New translations messages.json (Chinese Traditional)

* Fix reloading after updated by /qs update

* Stop reloading after updated by /qs update

* Catching exception in reload command

* New translations messages.json (Korean)

* New translations messages.json (Korean)

* New translations messages.json (Czech)

* New translations messages.json (Turkish)

* Fix loading timer issue

* Add GroupManager check

* Fix timer issue

* New translations messages.json (Turkish)

* New translations messages.json (Turkish)

* New translations messages.json (Turkish)

* New translations messages.json (Finnish)

* New translations messages.json (Finnish)

* debug vdisplay

* debug vdisplay

* Keep debugging

* Only try convert packet

* Only try convert packet

* Prevent user reload quickshop after use command /qs update

* Also cancel tasks when we setup boot error

* Fix onCommand sound issue

* Fix ArrayIndexOutOfBoundsException when having boot error

* Fix ArrayIndexOutOfBoundsException in CommandManager

* Fix bug in `fix bug`

* Fix incorrect string calling

* New translations messages.json (German)

* Update maven.yml

* bump version

* fix maven conflict

* New translations messages.json (Chinese Simplified)

* Bump helper from 5.6.5 to 5.6.8

Bumps [helper](https://github.com/lucko/helper) from 5.6.5 to 5.6.8.
- [Release notes](https://github.com/lucko/helper/releases)
- [Commits](https://github.com/lucko/helper/commits)

---
updated-dependencies:
- dependency-name: me.lucko:helper
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>

* Re-add outdated api methods to improve backward compatibility. Schedule removal in v5

* Add support for PlotSquared 6 (WIP) (#1208)

* Add support for PlotSquared 6 (WIP)

* Resolved package name conflicting by multiple projects

* Fix build

* Fix bug when using getShopWithCaching

* New translations messages.json (Russian)

* New translations messages.json (Russian)

* Wrong JDK name fixed (#1226)

Shouldn't this be JDK 16? (Because it says java-version: '16'...)

* Extract shop loading out of loop, fixed #1151

* Allow all transparent block

* New translations messages.json (Chinese Simplified)

* move to async thread

* Todo

* Refactor to use EconomyTransaction

* New translations messages.json (Japanese)

* New translations messages.json (Spanish)

* Fix shop sign is editable

* Added sign feature, solved #1155

* Fix WorldGuard Integration not work missing after reloading

* New translations messages.json (Chinese Simplified)

* New translations messages.json (Finnish)

* Fix the compatibility of VirtualDisplayItem on 1.17.1
Fix #1264

* Fix the compatibility of VirtualDisplayItem on 1.17.1 Fix #1264

* Fix NullPointerException when creating shop

* Add sign placement checking and improve sign change checking

* Bump version

* Bump ProtocolLib from 4.7.0-SNAPSHOT to 4.7.0

Bumps [ProtocolLib](https://github.com/dmulloy2/ProtocolLib) from 4.7.0-SNAPSHOT to 4.7.0.
- [Release notes](https://github.com/dmulloy2/ProtocolLib/releases)
- [Commits](https://github.com/dmulloy2/ProtocolLib/commits/4.7.0)

---
updated-dependencies:
- dependency-name: com.comphenix.protocol:ProtocolLib
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>

* Improve Ongoing Fee logic

* Add missed allowLoan condition

* Fix version comparing bug

* Replace check to common sign

Co-authored-by: Ghost_chu <30802565+Ghost-chu@users.noreply.github.com>
Co-authored-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
Co-authored-by: Ghost_chu <2908803755@qq.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Co-authored-by: Chris <65610536+Chris6ix@users.noreply.github.com>