### PR TITLE
Fixed some things in the Grief Prevention Integration to consider subclaims

### DIFF
--- a/src/main/java/org/maxgamer/quickshop/QuickShop.java
+++ b/src/main/java/org/maxgamer/quickshop/QuickShop.java
@@ -1864,6 +1864,10 @@ public class QuickShop extends JavaPlugin {
             getConfig().set("integration.griefprevention.delete-on-claim-expired", false);
             getConfig().set("config-version", ++selectedVersion);
         }
+        if (selectedVersion == 134) {
+            getConfig().set("integration.griefprevention.delete-on-claim-resized", false);
+            getConfig().set("config-version", ++selectedVersion);
+        }
 
 
         if (getConfig().getInt("matcher.work-type") != 0 && GameVersion.get(ReflectFactory.getServerVersion()).name().contains("1_16")) {

--- a/src/main/java/org/maxgamer/quickshop/integration/griefprevention/GriefPreventionIntegration.java
+++ b/src/main/java/org/maxgamer/quickshop/integration/griefprevention/GriefPreventionIntegration.java
@@ -109,41 +109,27 @@ public class GriefPreventionIntegration extends QSIntegratedPlugin {
         if (!deleteOnUntrusted) {
             return;
         }
-        if (event.isGiven()) {
-            return;
-        }
-
         for (Claim claim : event.getClaims()) {
             for (Chunk chunk : claim.getChunks()) {
                 Map<Location, Shop> shops = plugin.getShopManager().getShops(chunk);
                 if (shops != null) {
                     for (Shop shop : shops.values()) {
-                        if (shop.getOwner().equals(claim.getOwnerID())) {
-                            return;
-                        }
+                        if (!shop.getOwner().equals(claim.getOwnerID())) {
 
-                        Claim shopClaim = griefPrevention.dataStore.getClaimAt(shop.getLocation(), true, true, null);
-                        if(shopClaim == null || shopClaim.getID() != claim.getID()) {
-                            return;
-                        }
+                            Claim shopClaim = griefPrevention.dataStore.getClaimAt(shop.getLocation(), true, false, null);
+                            if(shopClaim != null && shopClaim.getID() == claim.getID()) {
 
-                        //https://github.com/TechFortress/GriefPrevention/blob/e63d1d9e513f48aa0aaa81f154de01626248b7fe/src/main/java/me/ryanhamshire/GriefPrevention/events/TrustChangedEvent.java#L104
-                        if (event.getIdentifier().equals(shop.getOwner().toString())) { //Single
-                            plugin.log("[SHOP DELETE] GP Integration: Single delete #" + event.getIdentifier());
-                            shop.delete();
-                            return;
-                        }
-
-                        if (event.getIdentifier().contains(shop.getOwner().toString())) { //Group
-                            plugin.log("[SHOP DELETE] GP Integration: Group delete #" + event.getIdentifier());
-                            shop.delete();
-                            return;
-                        }
-
-                        if ("all".equals(event.getIdentifier()) || "public".equals(event.getIdentifier())) { //All
-                            plugin.log("[SHOP DELETE] GP Integration: All/Public delete #" + event.getIdentifier());
-                            shop.delete();
-                            return;
+                                if(event.getIdentifier().equals(shop.getOwner().toString())) {
+                                    plugin.log("[SHOP DELETE] GP Integration: Single delete #" + event.getIdentifier());
+                                    shop.delete();
+                                } else if(event.getIdentifier().contains(shop.getOwner().toString())) {
+                                    plugin.log("[SHOP DELETE] GP Integration: Group delete #" + event.getIdentifier());
+                                    shop.delete();
+                                } else if("all".equals(event.getIdentifier()) || "public".equals(event.getIdentifier())) {
+                                    plugin.log("[SHOP DELETE] GP Integration: All/Public delete #" + event.getIdentifier());
+                                    shop.delete();
+                                }
+                            }
                         }
                     }
                 }
@@ -169,7 +155,7 @@ public class GriefPreventionIntegration extends QSIntegratedPlugin {
             Map<Location, Shop> shops = plugin.getShopManager().getShops(chunk);
             if (shops != null) {
                 for (Shop shop : shops.values()) {
-                    if (griefPrevention.dataStore.getClaimAt(shop.getLocation(), true, true, null) == null) {
+                    if (claim.contains(shop.getLocation(), true, false)) {
                         plugin.log("[SHOP DELETE] GP Integration: Single delete (Unclaimed/Expired) #" + shop.getOwner());
                         shop.delete();
                     }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -22,7 +22,7 @@
 #                        TO EDIT QUICKSHOP'S CONFIGURATION, USE THE "config.yml" FILE!
 
 #Do not touch this if you don't know what you're doing!
-config-version: 134
+config-version: 135
 
 #Select the language you want to use, (e.g de), use only supported language codes from the list below.
 #If you use a not existant/not supported language, then QuickShop will use en_US.
@@ -694,9 +694,11 @@ integration:
     #Should QuickShop delete shops if the shop owner has been untrusted on the claim?
     delete-on-untrusted: true
     #Should QuickShop delete shops if claim has been deleted?
-    delete-on-unclaim: false
+    delete-on-unclaim: true
     #Should QuickShop delete shops if claim has been expired?
     delete-on-claim-expired: true
+    #Should QuickShop delete shops if claim has been resized (claim has become smaller and the shop is now outside claim)?
+    delete-on-claim-resized: true
   #Residence Integration
   residence:
     enable: false


### PR DESCRIPTION
Changed code in the event handler of unclaimed/expired claim to consider subclaims. Fixed more problems in the event handler of untrusted claim to consider subclaims. Also removed the code event.isGiven() because if the player changes the trust permission from one greater level to another lower level, it does not consider as untrust, so it happens problems. Refactored the previous event because of the problems of the return statements inside loops.

Fixed many problems here ;) Also there is one thing missing in the plugin that I will add now, that is when players resize the claim and make it smaller, if the shop stays outside it, it will also remove it, i will create another listener to ModifiedClaim :p

Also would appreciate if you change my contributor name to RaphtaliaPT not Rean Schwarzer.