### PR TITLE
Update /qs paste URL and fix labels in issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -62,7 +62,7 @@ body:
         If you can't create a paste, should you upload other files such as the `latest.log` file to https://paste.helpch.at and share the URL.
 
         If QuickShop is unable to generate a Paste will it create a file under `plugins/QuickShop/`
-      placeholder: 'https://paste.ubuntu.com/p/abc123/'
+      placeholder: 'https://paste.helpch.at/...'
     validations:
       required: true
   - type: 'textarea'

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -3,7 +3,7 @@ description: 'Report a bug with QuickShop to us.'
 
 title: '[BUG] '
 labels:
-  - 'bug'
+  - 'Bug'
 
 body:
   - type: 'markdown'

--- a/.github/ISSUE_TEMPLATE/performance.yml
+++ b/.github/ISSUE_TEMPLATE/performance.yml
@@ -3,7 +3,7 @@ description: 'Report performance issues with QuickShop.'
 
 title: '[PERFORMANCE] '
 labels:
-  - 'performance'
+  - 'Performance Issue'
 
 body:
   - type: 'markdown'

--- a/.github/ISSUE_TEMPLATE/performance.yml
+++ b/.github/ISSUE_TEMPLATE/performance.yml
@@ -66,7 +66,7 @@ body:
         If you can't create a paste, should you upload other files such as the `latest.log` file to https://paste.helpch.at and share the URL.
 
         If QuickShop is unable to generate a Paste will it create a file under `plugins/QuickShop/`
-      placeholder: 'https://paste.ubuntu.com/p/abc123/'
+      placeholder: 'https://paste.helpch.at/...'
     validations:
       required: true
   - type: 'input'

--- a/.github/ISSUE_TEMPLATE/wiki_contribution.yml
+++ b/.github/ISSUE_TEMPLATE/wiki_contribution.yml
@@ -3,7 +3,7 @@ description: 'Inform about a Contribution that you want to make towards the wiki
 
 title: '[WIKI] '
 labels:
-  - 'wiki'
+  - 'Wiki'
 
 body:
   - type: 'markdown'


### PR DESCRIPTION
- Updates the URL placeholder in the `/qs paste` field
- Fixes wrong label names used